### PR TITLE
feat(.well-known/pay): add own payment pointer with rev sharing

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -15,6 +15,7 @@ import caniuseRouter from "./routes/caniuse/index.js";
 import githubRouter from "./routes/github/index.js";
 import respecRouter from "./routes/respec/index.js";
 import w3cRouter from "./routes/w3c/index.js";
+import wellKnownRouter from "./routes/well-known/index.js";
 import docsRouter from "./routes/docs/index.js";
 
 const app = express();
@@ -44,6 +45,7 @@ app.use("/caniuse", caniuseRouter);
 app.use("/github/:org/:repo", githubRouter);
 app.use("/respec", respecRouter);
 app.use("/w3c", w3cRouter);
+app.use("/.well-known", wellKnownRouter);
 app.use("/docs", docsRouter);
 app.get("/", (_req, res) => res.redirect("/docs/"));
 

--- a/routes/well-known/index.ts
+++ b/routes/well-known/index.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import cors from "cors";
+
+import payRoute from "./pay.js";
+
+const routes = Router();
+routes.get("/pay", cors(), payRoute);
+
+export default routes;

--- a/routes/well-known/pay.ts
+++ b/routes/well-known/pay.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from "express";
+import fetch from "node-fetch";
+
+const PAYMENT_POINTERS = [
+  "$ilp.uphold.com/DwJmxPHHi8K3", // Marcos
+  "$ilp.uphold.com/PM3RAZfjyXWf", // Sid
+].map(paymentPointerToURL);
+
+export default async function route(_req: Request, res: Response) {
+  const paymentPointer = random(PAYMENT_POINTERS);
+  const spsp = await fetch(paymentPointer, {
+    headers: { accept: "application/spsp4+json" },
+  }).then(r => r.json());
+  res.json(spsp);
+}
+
+function random<T>(list: T[]) {
+  const idx = Math.floor(Math.random() * list.length);
+  return list[idx];
+}
+
+// https://paymentpointers.org/syntax-resolution/
+function paymentPointerToURL(pointer: string) {
+  const url = new URL(pointer.replace(/^\$/, "https://"));
+  if (!url.pathname) {
+    url.pathname = "/.well-known/pay";
+  }
+  return url;
+}

--- a/routes/well-known/pay.ts
+++ b/routes/well-known/pay.ts
@@ -22,7 +22,7 @@ function random<T>(list: T[]) {
 // https://paymentpointers.org/syntax-resolution/
 function paymentPointerToURL(pointer: string) {
   const url = new URL(pointer.replace(/^\$/, "https://"));
-  if (!url.pathname) {
+  if (url.pathname === "/") {
     url.pathname = "/.well-known/pay";
   }
   return url;


### PR DESCRIPTION
In respec, we can now use `$respec.org` as payment pointer.