### PR TITLE
feat(xref): support IDL constants

### DIFF
--- a/routes/xref/lib/constants.ts
+++ b/routes/xref/lib/constants.ts
@@ -2,6 +2,7 @@ export const IDL_TYPES = new Set([
   "_IDL_",
   "attribute",
   "callback",
+  "const",
   "dict-member",
   "dictionary",
   "enum-value",


### PR DESCRIPTION
Fixes #203 

@marcoscaceres With no further changes, constants can now be referenced  in ReSpec as `{{HTMLMediaElement/HAVE_METADATA}}` (though they've no particular data-type). Do we want a different syntax (mainly to disambiguate `data-type` in case it's needed; maybe `{{HTMLMediaElement::HAVE_METADATA}}`)?