### PR TITLE
docs(src): add latestVersion

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -281,6 +281,7 @@
       <section data-include="errata"></section>
       <section data-include="group"></section>
       <section data-include="implementationReportURI"></section>
+      <section data-include="latestVersion"></section>
       <section data-include="lcEnd"></section>
       <section data-include="level"></section>
       <section data-include="noRecTrack"></section>


### PR DESCRIPTION
Adds `latestVersion` to docs, as a W3C only option.