### PR TITLE
fix(xref/ui): add SyntaxError to exception exceptions

### DIFF
--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -94,6 +94,7 @@ const exceptionExceptions = new Set([
   'EvalError',
   'RangeError',
   'ReferenceError',
+  'SyntaxError',
   'TypeError',
   'URIError',
 ]);


### PR DESCRIPTION
closes #232 