### PR TITLE
fix(xref/ui): improve last update date format

### DIFF
--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -238,8 +238,9 @@ async function ready() {
   const lastUpdated = new Date(version);
   /** @type {HTMLTimeElement} */
   const lastUpdatedEl = document.getElementById('last-updated-date');
-  lastUpdatedEl.textContent = lastUpdated.toLocaleString(undefined, {
-    timeZoneName: 'short',
+  lastUpdatedEl.textContent = lastUpdated.toLocaleString('default', {
+    dateStyle: 'long',
+    timeStyle: 'long',
   });
   lastUpdatedEl.dateTime = lastUpdated.toISOString();
 


### PR DESCRIPTION
Closes https://github.com/w3c/respec-web-services/issues/235
Looks like `11 October 2021 at 5:41:19 pm IST` for me.