### PR TITLE
refactor(scripts/*): use top-level await

### DIFF
--- a/scripts/regenerate-docs.ts
+++ b/scripts/regenerate-docs.ts
@@ -1,8 +1,6 @@
 import { regenerateDocs } from "../routes/docs/update.js";
 
-(async () => {
-  const start = Date.now();
-  console.log("Regenerating docs...");
-  await regenerateDocs();
-  console.log(`Successfully regenerated docs in ${Date.now() - start}ms.`);
-})();
+const start = Date.now();
+console.log("Regenerating docs...");
+await regenerateDocs();
+console.log(`Successfully regenerated docs in ${Date.now() - start}ms.`);

--- a/scripts/update-data-sources.ts
+++ b/scripts/update-data-sources.ts
@@ -5,24 +5,17 @@ import caniuse from "../routes/caniuse/lib/scraper.js";
 import xref from "../routes/xref/lib/scraper.js";
 import w3cGroupsList from "./update-w3c-groups-list.js";
 
-async function update() {
-  // ensure the data directory exists
-  await mkdir(env("DATA_DIR"), { recursive: true });
+// ensure the data directory exists
+await mkdir(env("DATA_DIR"), { recursive: true });
 
-  console.group("caniuse");
-  await caniuse({ forceUpdate: true });
-  console.groupEnd();
+console.group("caniuse");
+await caniuse({ forceUpdate: true });
+console.groupEnd();
 
-  console.group("xref");
-  await xref({ forceUpdate: true });
-  console.groupEnd();
+console.group("xref");
+await xref({ forceUpdate: true });
+console.groupEnd();
 
-  console.group("W3C Groups List");
-  await w3cGroupsList();
-  console.groupEnd();
-}
-
-update().catch(error => {
-  console.log(error);
-  process.exit(1);
-});
+console.group("W3C Groups List");
+await w3cGroupsList();
+console.groupEnd();

--- a/scripts/update-w3c-groups-list.ts
+++ b/scripts/update-w3c-groups-list.ts
@@ -7,6 +7,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { writeFile, mkdir } from "fs/promises";
 
+import "dotenv/config";
 import fetch from "node-fetch";
 
 import { env } from "../utils/misc.js";
@@ -116,8 +117,5 @@ const runAsScript = (() => {
 })();
 
 if (runAsScript) {
-  update().catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+  await update();
 }


### PR DESCRIPTION
Closes https://github.com/w3c/respec-web-services/issues/198
Surprisingly very few.