### PR TITLE
fix(w3c/groups): use 'other' instead of 'misc', support AB

### DIFF
--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -15,7 +15,7 @@ export interface GroupMeta {
   name: string;
   URI: string;
 }
-type GroupType = "wg" | "cg" | "ig" | "bg" | "misc";
+type GroupType = "wg" | "cg" | "ig" | "bg" | "other";
 export type Groups = Record<string, GroupMeta>;
 export type GroupsByType = Record<GroupType, Groups>;
 

--- a/scripts/update-w3c-groups-list.ts
+++ b/scripts/update-w3c-groups-list.ts
@@ -21,7 +21,7 @@ const mapGroupType = new Map([
   ["interest group", "ig"],
   ["working group", "wg"],
   // placeholder types (not matched by regular filters) follow:
-  ["_miscellaneous_", "misc"],
+  ["_miscellaneous_", "other"],
 ]);
 
 interface GroupResponse {
@@ -86,15 +86,16 @@ export default async function update() {
   }
 
   // Exceptional groups that don't follow norms like other group types.
-  const miscGroupFilters = [
+  const otherGroupFilters = [
     (group: GroupResponse) => group.shortname === "tag",
+    (group: GroupResponse) => group.shortname === "ab",
   ];
-  for (const filter of miscGroupFilters) {
+  for (const filter of otherGroupFilters) {
     const group = json._embedded.groups.find(filter);
     if (!group) continue;
     const { shortname, id, name, _links: links } = group;
     const url = links.homepage?.href;
-    data["misc"][shortname] = { id, name, URI: url };
+    data["other"][shortname] = { id, name, URI: url };
   }
 
   // Sort results for presentation.

--- a/views/w3c/groups.ts
+++ b/views/w3c/groups.ts
@@ -66,7 +66,7 @@ export default ({ groups }: { groups: GroupsByType }) => html`
         ${renderTable(groups.wg, "Working Groups")}
         ${renderTable(groups.bg, "Business Groups")}
         ${renderTable(groups.ig, "Interest Groups")}
-        ${renderTable(groups.other, "Miscellaneous Groups")}
+        ${renderTable(groups.other, "Other Groups")}
         ${renderTable(groups.cg, "Community Groups")}
       </div>
     </body>

--- a/views/w3c/groups.ts
+++ b/views/w3c/groups.ts
@@ -66,7 +66,7 @@ export default ({ groups }: { groups: GroupsByType }) => html`
         ${renderTable(groups.wg, "Working Groups")}
         ${renderTable(groups.bg, "Business Groups")}
         ${renderTable(groups.ig, "Interest Groups")}
-        ${renderTable(groups.misc, "Miscellaneous Groups")}
+        ${renderTable(groups.other, "Miscellaneous Groups")}
         ${renderTable(groups.cg, "Community Groups")}
       </div>
     </body>


### PR DESCRIPTION
This matches api.w3.org and www.w3.org/groups
Fixes https://github.com/w3c/respec-web-services/issues/243
