### PR TITLE
feat(w3c/groups): add wgURI to JSON response

### DIFF
--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -55,7 +55,7 @@ export default async function route(req: Request, res: Response) {
   if (type && !groups.hasOwnProperty(type)) {
     return res.status(404).send(`Invalid group type: "${type}".`);
   }
-  
+
   try {
     const requestedType = type as GroupType;
     const groupInfo = await getGroupInfo(shortname, requestedType);

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -120,6 +120,7 @@ async function fetchGroupInfo(
     type,
     id,
     name,
+    URI: links.homepage?.href,
     patentURI: links["pp-status"]?.href,
     patentPolicy,
     wgURI: `https://www.w3.org/groups/${type}/${shortname}`

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -55,6 +55,7 @@ export default async function route(req: Request, res: Response) {
   if (type && !groups.hasOwnProperty(type)) {
     return res.status(404).send(`Invalid group type: "${type}".`);
   }
+  
   try {
     const requestedType = type as GroupType;
     const groupInfo = await getGroupInfo(shortname, requestedType);

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -55,7 +55,6 @@ export default async function route(req: Request, res: Response) {
   if (type && !groups.hasOwnProperty(type)) {
     return res.status(404).send(`Invalid group type: "${type}".`);
   }
-
   try {
     const requestedType = type as GroupType;
     const groupInfo = await getGroupInfo(shortname, requestedType);
@@ -120,9 +119,9 @@ async function fetchGroupInfo(
     type,
     id,
     name,
-    URI: links.homepage?.href,
     patentURI: links["pp-status"]?.href,
     patentPolicy,
+    wgURI: `https://www.w3.org/groups/${type}/${shortname}`
   };
 }
 

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -27,6 +27,7 @@ interface Group {
   shortname: string;
   type: GroupType;
   name: string;
+  wgURI: string;
   URI?: string;
   patentURI?: string;
   patentPolicy?: "PP2017" | "PP2020" | null;


### PR DESCRIPTION
The W3C now has "special" URLs for the wgURI. 

then I can get rid of:
https://github.com/w3c/respec/pull/3848/files#diff-13273a4f4852f048daddcee7ee5d06a808e5ba8edf4e7c6a3472c5176faed45c

