### PR TITLE
fix(docs): use default license

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -21,7 +21,6 @@
             url: "https://github.com/w3c/respec",
           },
         ],
-        license: "cc0",
         lint: {
           "no-http-props": false,
           "check-punctuation": true,


### PR DESCRIPTION
Use the w3c permissive license (default). 