### PR TITLE
docs: remove wgPatentPolicy, as it is internal

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -291,7 +291,6 @@
       <section data-include="prevRecShortname"></section>
       <section data-include="prevRecURI"></section>
       <section data-include="submissionCommentNumber"></section>
-      <section data-include="wgPatentPolicy"></section>
       <section data-include="wgPublicList"></section>
     </section>
     <section id="special-section-ids">


### PR DESCRIPTION
It's accidentally listed twice (see 13.5). 