### PR TITLE
fix(/caniuse/:feature): return 404 if feature not on file

### DIFF
--- a/routes/caniuse/feature.ts
+++ b/routes/caniuse/feature.ts
@@ -13,6 +13,10 @@ export default async function route(req: IRequest, res: Response) {
 
   try {
     const data = await getData(feature);
+    if (data === null) {
+      res.sendStatus(404);
+      return;
+    }
     const result = [];
     for (const browser of browsers) {
       result.push({ browser, ...getBrowserData(data?.all[browser]) });

--- a/routes/caniuse/feature.ts
+++ b/routes/caniuse/feature.ts
@@ -11,6 +11,7 @@ export default async function route(req: IRequest, res: Response) {
   const { feature } = req.params;
   const browsers = normalizeBrowsers(req.query.browsers);
 
+
   try {
     const data = await getData(feature);
     if (data === null) {

--- a/routes/caniuse/feature.ts
+++ b/routes/caniuse/feature.ts
@@ -11,7 +11,6 @@ export default async function route(req: IRequest, res: Response) {
   const { feature } = req.params;
   const browsers = normalizeBrowsers(req.query.browsers);
 
-
   try {
     const data = await getData(feature);
     const result = [];

--- a/routes/caniuse/lib/index.ts
+++ b/routes/caniuse/lib/index.ts
@@ -109,20 +109,20 @@ export async function getData(feature: string) {
   if (cache.has(feature)) {
     return cache.get(feature) as Data;
   }
+
   const file = path.format({
     dir: path.join(DATA_DIR, "caniuse"),
     name: `${feature}.json`,
   });
-
   try {
-    const str = await fs.readFile(file, "utf8");
-    const data: Data = JSON.parse(str);
-    cache.set(feature, data);
-    return data;
-  } catch (error) {
-    console.error(error);
-    return null;
+    await fs.stat(file);
+  } catch (err) {
+    throw new Error(`Feature "${feature}" not found.`);
   }
+  const str = await fs.readFile(file, "utf8");
+  const data: Data = JSON.parse(str);
+  cache.set(feature, data);
+  return data;
 }
 
 function formatAsHTML(

--- a/routes/caniuse/lib/index.ts
+++ b/routes/caniuse/lib/index.ts
@@ -109,20 +109,20 @@ export async function getData(feature: string) {
   if (cache.has(feature)) {
     return cache.get(feature) as Data;
   }
-
   const file = path.format({
     dir: path.join(DATA_DIR, "caniuse"),
     name: `${feature}.json`,
   });
+
   try {
-    await fs.stat(file);
-  } catch (err) {
-    throw new Error(`Feature "${feature}" not found.`);
+    const str = await fs.readFile(file, "utf8");
+    const data: Data = JSON.parse(str);
+    cache.set(feature, data);
+    return data;
+  } catch (error) {
+    console.error(error);
+    return null;
   }
-  const str = await fs.readFile(file, "utf8");
-  const data: Data = JSON.parse(str);
-  cache.set(feature, data);
-  return data;
 }
 
 function formatAsHTML(


### PR DESCRIPTION
Returns a 404 if /caniuse/whatever is not a file on the server, but without exposing the lstat details in the response. 

We then show the right error on the front-end. 

I also made the fails a bit more aggressive by not returning `null`... if it fails, we should really be returning 500s and dealing with that on the client.  