### PR TITLE
chore(/caniuse): monitor usage of deprecated route

### DIFF
--- a/routes/caniuse/index.ts
+++ b/routes/caniuse/index.ts
@@ -26,6 +26,7 @@ interface Query {
 type IRequest = Request<any, any, any, Query>;
 
 export async function route(req: IRequest, res: Response) {
+  res.locals.deprecated = true;
   const options = {
     feature: req.query.feature,
     browsers: req.query.browsers ? req.query.browsers.split(",") : "default",

--- a/utils/logging.ts
+++ b/utils/logging.ts
@@ -57,9 +57,13 @@ const formatter: FormatFn<Request, Response> = (tokens, req, res) => {
   const searchParams = url.search
     ? decodeURIComponent(url.search).replace(/(\s+)/g, encodeURIComponent)
     : "";
-  const color = status < 300 ? "green" : status >= 400 ? "red" : "yellow";
+  let color =
+    status < 300 ? chalk.green : status >= 400 ? chalk.red : chalk.yellow;
+  if (res.locals.deprecated) {
+    color = color.underline;
+  }
   const request =
-    chalk[color](`${method!.padEnd(4)} ${status}`) +
+    color(`${method!.padEnd(4)} ${status}`) +
     ` ${chalk.blueBright(url.pathname)}${chalk.italic.gray(searchParams)}`;
 
   let formattedReferrer: string | undefined;


### PR DESCRIPTION
As suggested in https://github.com/w3c/respec-web-services/pull/272#discussion_r825816749

1. a `deprecated` field is added to filter logs
2. the status in logs is underlined for deprecated routes

![image](https://user-images.githubusercontent.com/8426945/158160686-8b656eaf-0092-4331-a2be-2e8c34130ff5.png)
