### PR TITLE
docs(src.html): fix nolinks, remove data-export, add conformance

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -320,7 +320,7 @@
       <section data-include="issue"></section>
       <section data-include="no-link-warnings"></section>
       <section data-include="nohighlight"></section>
-      <section data-include="nolink"></section>
+      <section data-include="nolinks"></section>
       <section data-include="note"></section>
       <section data-include="notoc-class"></section>
       <section data-include="override"></section>
@@ -340,7 +340,6 @@
       <section data-include="data-cite"></section>
       <section data-include="data-dfn-for"></section>
       <section data-include="data-dfn-type"></section>
-      <section data-include="data-export"></section>
       <section data-include="data-format"></section>
       <section data-include="data-include"></section>
       <section data-include="data-include-format"></section>
@@ -415,5 +414,6 @@
         </li>
       </ol>
     </section>
+    <section id="conformance" class="removeOnSave"></section>
   </body>
 </html>


### PR DESCRIPTION
nolink was 404, as it was actually "nolinks". 

data-export now contains the css class only. 

And added conformance section to get rid of the warning, which gets removed on save. 