### PR TITLE
fix(w3c/groups): better hint if multiple groups with same shortname

### DIFF
--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -182,8 +182,8 @@ function getGroupMeta(shortname: string, requestedType: GroupType) {
     }
     default: {
       const msg = `Multiple groups with shortname: "${shortname}".`;
-      const suggestions = data.map(g => `"${g.type}"`).join(", ");
-      const hint = `Specify one of following group types: ${suggestions}.`;
+      const suggestions = data.map(g => `"${g.type}/${shortname}"`).join(", ");
+      const hint = `Please use either: ${suggestions}.`;
       throw new HTTPError(409, `${msg}\n${hint}`);
     }
   }


### PR DESCRIPTION
Fixes https://github.com/w3c/respec-web-services/issues/326