### PR TITLE
fix(docs/src): add prEnd, remove lcEnd

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -283,9 +283,9 @@
       <section data-include="group"></section>
       <section data-include="implementationReportURI"></section>
       <section data-include="latestVersion"></section>
-      <section data-include="lcEnd"></section>
       <section data-include="level"></section>
       <section data-include="noRecTrack"></section>
+      <section data-include="prEnd"></section>
       <section data-include="prevED"></section>
       <section data-include="previousDiffURI"></section>
       <section data-include="previousMaturity"></section>


### PR DESCRIPTION
closes #404 

Checked that it is indeed not in the codebase