### PR TITLE
fix(xref:ui): escape HTML in spec title

### DIFF
--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -148,7 +148,9 @@ function renderResults(entries, query) {
   for (const entry of entries) {
     const specInfo = metadata.specs[entry.status][entry.spec];
     const link = new URL(entry.uri, specInfo.url).href;
-    const title = specInfo.title;
+    const title = specInfo.title.replaceAll(/[<>]/g, match => {
+      return match === '<' ? '&lt;' : '&gt;';
+    });
     const cite = metadata.types.idl.has(entry.type)
       ? howToCiteIDL(term, entry)
       : metadata.types.markup.has(entry.type)

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -148,9 +148,7 @@ function renderResults(entries, query) {
   for (const entry of entries) {
     const specInfo = metadata.specs[entry.status][entry.spec];
     const link = new URL(entry.uri, specInfo.url).href;
-    const title = specInfo.title.replaceAll(/[<>]/g, match => {
-      return match === '<' ? '&lt;' : '&gt;';
-    });
+    const title = escapeHTML(specInfo.title);
     const cite = metadata.types.idl.has(entry.type)
       ? howToCiteIDL(term, entry)
       : metadata.types.markup.has(entry.type)


### PR DESCRIPTION
For specs like "The <model> element", which otherwise end up as actual HTML tags 😬