### PR TITLE
fix(/docs/update): update spec-generator URL

### DIFF
--- a/routes/docs/update.ts
+++ b/routes/docs/update.ts
@@ -23,7 +23,7 @@ export default async function route(_req: Request, res: Response) {
 }
 
 export async function regenerateDocs() {
-  const url = new URL("https://labs.w3.org/spec-generator/");
+  const url = new URL("https://www.w3.org/publications/spec-generator/");
   url.searchParams.set("type", "respec");
   url.searchParams.set("url", "https://respec.org/docs/src.html");
 


### PR DESCRIPTION
This updates the domain and path to match the new URL announced in https://lists.w3.org/Archives/Public/spec-prod/2025OctDec/0008.html