### PR TITLE
feat(xref): add headings lookup API for cross-spec section links

### DIFF
--- a/routes/xref/headings.post.ts
+++ b/routes/xref/headings.post.ts
@@ -34,15 +34,13 @@ export default function route(req: IRequest, res: Response) {
   }
   for (const item of queries) {
     if (typeof item?.spec !== "string" || typeof item?.id !== "string") {
-      res
-        .status(400)
-        .json({ error: "each query must have string fields: spec, id" });
+      res.status(400);
+      res.json({ error: "each query must have string fields: spec, id" });
       return;
     }
     if (!item.spec.trim() || !item.id.trim()) {
-      res
-        .status(400)
-        .json({ error: "spec and id must be non-empty strings" });
+      res.status(400);
+      res.json({ error: "spec and id must be non-empty strings" });
       return;
     }
   }

--- a/routes/xref/headings.post.ts
+++ b/routes/xref/headings.post.ts
@@ -13,7 +13,7 @@ interface RequestBody {
 type IRequest = Request<never, any, RequestBody>;
 
 /**
- * POST /xref/headings
+ * POST /xref/search/headings
  *
  * Looks up section headings by spec shortname and fragment id.
  * Used by ReSpec's [[[SPEC#id]]] syntax to get heading text for
@@ -28,11 +28,21 @@ export default function route(req: IRequest, res: Response) {
     res.status(400).json({ error: "queries must be an array" });
     return;
   }
+  if (queries.length > 1000) {
+    res.status(400).json({ error: "too many queries (max 1000)" });
+    return;
+  }
   for (const item of queries) {
     if (typeof item?.spec !== "string" || typeof item?.id !== "string") {
       res
         .status(400)
         .json({ error: "each query must have string fields: spec, id" });
+      return;
+    }
+    if (!item.spec.trim() || !item.id.trim()) {
+      res
+        .status(400)
+        .json({ error: "spec and id must be non-empty strings" });
       return;
     }
   }

--- a/routes/xref/headings.post.ts
+++ b/routes/xref/headings.post.ts
@@ -28,6 +28,14 @@ export default function route(req: IRequest, res: Response) {
     res.status(400).json({ error: "queries must be an array" });
     return;
   }
+  for (const item of queries) {
+    if (typeof item?.spec !== "string" || typeof item?.id !== "string") {
+      res
+        .status(400)
+        .json({ error: "each query must have string fields: spec, id" });
+      return;
+    }
+  }
   const result = queries.map(({ spec, id }) => {
     const heading = store.getHeading(spec, id);
     if (!heading) {

--- a/routes/xref/headings.post.ts
+++ b/routes/xref/headings.post.ts
@@ -23,7 +23,11 @@ type IRequest = Request<never, any, RequestBody>;
  * Response: { result: [{ spec: "fetch", id: "cookie-header", ... }] }
  */
 export default function route(req: IRequest, res: Response) {
-  const { queries = [] } = req.body;
+  const { queries } = req.body;
+  if (!Array.isArray(queries)) {
+    res.status(400).json({ error: "queries must be an array" });
+    return;
+  }
   const result = queries.map(({ spec, id }) => {
     const heading = store.getHeading(spec, id);
     if (!heading) {

--- a/routes/xref/headings.post.ts
+++ b/routes/xref/headings.post.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from "express";
+import { store } from "./lib/store-init.js";
+
+interface HeadingsQuery {
+  spec: string;
+  id: string;
+}
+
+interface RequestBody {
+  queries: HeadingsQuery[];
+}
+
+type IRequest = Request<never, any, RequestBody>;
+
+/**
+ * POST /xref/headings
+ *
+ * Looks up section headings by spec shortname and fragment id.
+ * Used by ReSpec's [[[SPEC#id]]] syntax to get heading text for
+ * cross-spec section links.
+ *
+ * Request body: { queries: [{ spec: "fetch", id: "cookie-header" }] }
+ * Response: { result: [{ spec: "fetch", id: "cookie-header", ... }] }
+ */
+export default function route(req: IRequest, res: Response) {
+  const { queries = [] } = req.body;
+  const result = queries.map(({ spec, id }) => {
+    const heading = store.getHeading(spec, id);
+    if (!heading) {
+      return { spec, id, error: "not found" };
+    }
+    return {
+      spec,
+      id,
+      title: heading.title,
+      number: heading.number || null,
+      href: heading.href,
+      level: heading.level,
+      specTitle: heading.specTitle,
+    };
+  });
+  res.json({ result });
+}

--- a/routes/xref/headings.post.ts
+++ b/routes/xref/headings.post.ts
@@ -47,7 +47,7 @@ export default function route(req: IRequest, res: Response) {
     }
   }
   const result = queries.map(({ spec, id }) => {
-    const heading = store.getHeading(spec, id);
+    const heading = store.getHeading(spec.trim(), id.trim());
     if (!heading) {
       return { spec, id, error: "not found" };
     }

--- a/routes/xref/index.ts
+++ b/routes/xref/index.ts
@@ -10,6 +10,7 @@ import { env, ms } from "../../utils/misc.js";
 import { store } from "./lib/store-init.js";
 import searchRouteGet from "./search.get.js";
 import searchRoutePost from "./search.post.js";
+import headingsRoutePost from "./headings.post.js";
 import metaRoute from "./meta.js";
 import updateRoute from "./update.js";
 import { search, Options, Query } from "./lib/search.js";
@@ -26,6 +27,9 @@ xref
   .get("/search", cors(), searchRouteGet)
   .post("/search", express.json({ limit: "2mb" }), cors(), searchRoutePost);
 xref.get("/meta{/:field}", cors(), metaRoute);
+xref
+  .options("/headings", cors({ methods: ["POST"], maxAge: ms("1day") }))
+  .post("/headings", express.json({ limit: "1mb" }), cors(), headingsRoutePost);
 xref.post("/update", authGithubWebhook(env("W3C_WEBREF_SECRET")), updateRoute);
 xref.use("/data", express.static(path.join(DATA_DIR, "xref")));
 

--- a/routes/xref/index.ts
+++ b/routes/xref/index.ts
@@ -10,6 +10,7 @@ import { env, ms } from "../../utils/misc.js";
 import { store } from "./lib/store-init.js";
 import searchRouteGet from "./search.get.js";
 import searchRoutePost from "./search.post.js";
+import headingsRoutePost from "./headings.post.js";
 import metaRoute from "./meta.js";
 import updateRoute from "./update.js";
 import { search, Options, Query } from "./lib/search.js";
@@ -26,6 +27,9 @@ xref
   .get("/search", cors(), searchRouteGet)
   .post("/search", express.json({ limit: "2mb" }), cors(), searchRoutePost);
 xref.get("/meta/:field?", cors(), metaRoute);
+xref
+  .options("/headings", cors({ methods: ["POST"], maxAge: ms("1day") }))
+  .post("/headings", express.json({ limit: "1mb" }), cors(), headingsRoutePost);
 xref.post("/update", authGithubWebhook(env("W3C_WEBREF_SECRET")), updateRoute);
 xref.use("/data", express.static(path.join(DATA_DIR, "xref")));
 

--- a/routes/xref/index.ts
+++ b/routes/xref/index.ts
@@ -28,8 +28,8 @@ xref
   .post("/search", express.json({ limit: "2mb" }), cors(), searchRoutePost);
 xref.get("/meta{/:field}", cors(), metaRoute);
 xref
-  .options("/headings", cors({ methods: ["POST"], maxAge: ms("1day") }))
-  .post("/headings", express.json({ limit: "1mb" }), cors(), headingsRoutePost);
+  .options("/search/headings", cors({ methods: ["POST"], maxAge: ms("1day") }))
+  .post("/search/headings", express.json({ limit: "1mb" }), cors(), headingsRoutePost);
 xref.post("/update", authGithubWebhook(env("W3C_WEBREF_SECRET")), updateRoute);
 xref.use("/data", express.static(path.join(DATA_DIR, "xref")));
 

--- a/routes/xref/lib/scraper.ts
+++ b/routes/xref/lib/scraper.ts
@@ -247,7 +247,7 @@ async function readJSON(filePath: string) {
 
 /**
  * Read all headings data from webref's ed/headings/ directory.
- * Builds a map of { shortname: { id: HeadingEntry } } for fast lookup.
+ * Returns { shortname: HeadingEntry[] }. Indexed by id in the Store.
  */
 async function readAllHeadings(
   headingsDir: string,

--- a/routes/xref/lib/scraper.ts
+++ b/routes/xref/lib/scraper.ts
@@ -5,7 +5,7 @@
 
 import path from "path";
 import { existsSync } from "fs";
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 
 import { Definition as InputDfn, DfnsJSON, SpecsJSON } from "webref";
 
@@ -52,6 +52,11 @@ export interface HeadingEntry {
 
 export interface HeadingsBySpec {
   [shortname: string]: HeadingEntry[];
+}
+
+interface HeadingsJSON {
+  spec?: { shortname?: string };
+  headings?: HeadingEntry[];
 }
 
 const defaultOptions = { forceUpdate: false };
@@ -212,7 +217,7 @@ function normalizeTerm(term: string, type: string) {
 async function getAllData(baseDir: string) {
   const SPECS_JSON = path.resolve(baseDir, "./index.json");
   console.log(`Getting data from ${SPECS_JSON}`);
-  const urlFileContent = await readJSON(SPECS_JSON);
+  const urlFileContent = await readJSON<{ results: SpecsJSON[] }>(SPECS_JSON);
   const data: SpecsJSON[] = urlFileContent.results;
 
   const specMap: Store["specmap"] = Object.create(null);
@@ -220,7 +225,7 @@ async function getAllData(baseDir: string) {
 
   for (const entry of data) {
     if (entry.dfns) {
-      const dfnsData = await readJSON(path.join(baseDir, entry.dfns));
+      const dfnsData = await readJSON<{ dfns: InputDfn[] }>(path.join(baseDir, entry.dfns));
       const dfns: InputDfn[] = dfnsData.dfns;
       dfnSources.push({
         series: entry.series.shortname,
@@ -240,9 +245,9 @@ async function getAllData(baseDir: string) {
   return { specMap, dfnSources };
 }
 
-async function readJSON(filePath: string) {
+async function readJSON<T = unknown>(filePath: string): Promise<T> {
   const text = await readFile(filePath, "utf-8");
-  return JSON.parse(text);
+  return JSON.parse(text) as T;
 }
 
 /**
@@ -258,25 +263,22 @@ async function readAllHeadings(
     return result;
   }
 
-  const { readdir } = await import("fs/promises");
   const files = await readdir(headingsDir);
   const jsonFiles = files.filter(f => f.endsWith(".json"));
 
   console.log(`Processing ${jsonFiles.length} heading files...`);
   for (const file of jsonFiles) {
     try {
-      const data = await readJSON(path.join(headingsDir, file));
+      const data = await readJSON<HeadingsJSON>(path.join(headingsDir, file));
       const shortname = data.spec?.shortname?.toLowerCase()
         || file.replace(/\.json$/, "").toLowerCase();
-      const headings: HeadingEntry[] = (data.headings || []).map(
-        (h: { id: string; href: string; title: string; number?: string; level: number }) => ({
-          id: h.id,
-          href: h.href,
-          title: h.title,
-          number: h.number,
-          level: h.level,
-        }),
-      );
+      const headings: HeadingEntry[] = (data.headings || []).map(h => ({
+        id: h.id,
+        href: h.href,
+        title: h.title,
+        number: h.number,
+        level: h.level,
+      }));
       result[shortname] = headings;
     } catch (error) {
       console.error(`Error reading headings from ${file}:`, error);

--- a/routes/xref/lib/scraper.ts
+++ b/routes/xref/lib/scraper.ts
@@ -55,7 +55,6 @@ export interface HeadingsBySpec {
 }
 
 interface HeadingsJSON {
-  spec?: { shortname?: string };
   headings?: HeadingEntry[];
 }
 
@@ -270,8 +269,8 @@ async function readAllHeadings(
   for (const file of jsonFiles) {
     try {
       const data = await readJSON<HeadingsJSON>(path.join(headingsDir, file));
-      const shortname = data.spec?.shortname?.toLowerCase()
-        || file.replace(/\.json$/, "").toLowerCase();
+      // Shortname derived from filename (webref doesn't include it in the JSON)
+      const shortname = file.replace(/\.json$/, "").toLowerCase();
       const headings: HeadingEntry[] = (data.headings || []).map(h => ({
         id: h.id,
         href: h.href,

--- a/routes/xref/lib/scraper.ts
+++ b/routes/xref/lib/scraper.ts
@@ -11,7 +11,7 @@ import { Definition as InputDfn, DfnsJSON, SpecsJSON } from "webref";
 
 import { SUPPORTED_TYPES, CSS_TYPES_INPUT } from "./constants.js";
 import { uniq } from "./utils.js";
-import { Store } from "./store.js";
+import { Store, SpecMapGroup } from "./store.js";
 import { env } from "../../../utils/misc.js";
 import sh from "../../../utils/sh.js";
 
@@ -72,8 +72,8 @@ export default async function main(options: Partial<Options> = {}) {
   const dataByTerm: DataByTerm = Object.create(null);
   const dataBySpec: DataBySpec = Object.create(null);
   const specificationsMap = {
-    current: {} as Store["specmap"],
-    snapshot: {} as Store["specmap"],
+    current: {} as SpecMapGroup,
+    snapshot: {} as SpecMapGroup,
   };
 
   for (const [dir, status] of dirToStatus) {
@@ -219,7 +219,7 @@ async function getAllData(baseDir: string) {
   const urlFileContent = await readJSON<{ results: SpecsJSON[] }>(SPECS_JSON);
   const data: SpecsJSON[] = urlFileContent.results;
 
-  const specMap: Store["specmap"] = Object.create(null);
+  const specMap: SpecMapGroup = Object.create(null);
   const dfnSources: DfnsJSON[] = [];
 
   for (const entry of data) {

--- a/routes/xref/lib/scraper.ts
+++ b/routes/xref/lib/scraper.ts
@@ -25,6 +25,7 @@ const OUT_DIR_BASE = path.join(DATA_DIR, "xref");
 const OUTFILE_BY_TERM = path.resolve(OUT_DIR_BASE, "./xref.json");
 const OUTFILE_BY_SPEC = path.resolve(OUT_DIR_BASE, "./specs.json");
 const OUTFILE_SPECMAP = path.resolve(OUT_DIR_BASE, "./specmap.json");
+const OUTFILE_HEADINGS = path.resolve(OUT_DIR_BASE, "./headings.json");
 
 type Status = "current" | "snapshot";
 const dirToStatus = [
@@ -39,6 +40,18 @@ interface DataByTerm {
 }
 interface DataBySpec {
   [shortname: string]: Omit<ParsedDataEntry, "shortname" | "isExported">[];
+}
+
+export interface HeadingEntry {
+  id: string;
+  href: string;
+  title: string;
+  number?: string;
+  level: number;
+}
+
+export interface HeadingsBySpec {
+  [shortname: string]: HeadingEntry[];
 }
 
 const defaultOptions = { forceUpdate: false };
@@ -83,12 +96,18 @@ export default async function main(options: Partial<Options> = {}) {
     dataByTerm[term] = uniq(dataByTerm[term]);
   }
 
+  // Read headings data from webref (ed/ only, same as xref default)
+  const headingsBySpec = await readAllHeadings(
+    path.join(INPUT_DIR_BASE, "ed", "headings"),
+  );
+
   console.log("Writing processed data files...");
   await mkdir(OUT_DIR_BASE, { recursive: true });
   await Promise.all([
     writeFile(OUTFILE_BY_TERM, JSON.stringify(dataByTerm, null, 2)),
     writeFile(OUTFILE_BY_SPEC, JSON.stringify(dataBySpec, null, 2)),
     writeFile(OUTFILE_SPECMAP, JSON.stringify(specificationsMap, null, 2)),
+    writeFile(OUTFILE_HEADINGS, JSON.stringify(headingsBySpec, null, 2)),
   ]);
   return true;
 }
@@ -224,4 +243,45 @@ async function getAllData(baseDir: string) {
 async function readJSON(filePath: string) {
   const text = await readFile(filePath, "utf-8");
   return JSON.parse(text);
+}
+
+/**
+ * Read all headings data from webref's ed/headings/ directory.
+ * Builds a map of { shortname: { id: HeadingEntry } } for fast lookup.
+ */
+async function readAllHeadings(
+  headingsDir: string,
+): Promise<HeadingsBySpec> {
+  const result: HeadingsBySpec = Object.create(null);
+  if (!existsSync(headingsDir)) {
+    console.warn(`Headings directory not found: ${headingsDir}`);
+    return result;
+  }
+
+  const { readdir } = await import("fs/promises");
+  const files = await readdir(headingsDir);
+  const jsonFiles = files.filter(f => f.endsWith(".json"));
+
+  console.log(`Processing ${jsonFiles.length} heading files...`);
+  for (const file of jsonFiles) {
+    try {
+      const data = await readJSON(path.join(headingsDir, file));
+      const shortname = data.spec?.shortname?.toLowerCase()
+        || file.replace(/\.json$/, "").toLowerCase();
+      const headings: HeadingEntry[] = (data.headings || []).map(
+        (h: { id: string; href: string; title: string; number?: string; level: number }) => ({
+          id: h.id,
+          href: h.href,
+          title: h.title,
+          number: h.number,
+          level: h.level,
+        }),
+      );
+      result[shortname] = headings;
+    } catch (error) {
+      console.error(`Error reading headings from ${file}:`, error);
+    }
+  }
+
+  return result;
 }

--- a/routes/xref/lib/scraper.ts
+++ b/routes/xref/lib/scraper.ts
@@ -51,7 +51,7 @@ export interface HeadingEntry {
 }
 
 export interface HeadingsBySpec {
-  [shortname: string]: HeadingEntry[];
+  [shortname: string]: { [id: string]: HeadingEntry };
 }
 
 interface HeadingsJSON {
@@ -251,7 +251,7 @@ async function readJSON<T = unknown>(filePath: string): Promise<T> {
 
 /**
  * Read all headings data from webref's ed/headings/ directory.
- * Returns { shortname: HeadingEntry[] }. Indexed by id in the Store.
+ * Returns { shortname: { id: HeadingEntry } } — pre-indexed for O(1) lookup.
  */
 async function readAllHeadings(
   headingsDir: string,
@@ -271,14 +271,17 @@ async function readAllHeadings(
       const data = await readJSON<HeadingsJSON>(path.join(headingsDir, file));
       // Shortname derived from filename (webref doesn't include it in the JSON)
       const shortname = file.replace(/\.json$/, "").toLowerCase();
-      const headings: HeadingEntry[] = (data.headings || []).map(h => ({
-        id: h.id,
-        href: h.href,
-        title: h.title,
-        number: h.number,
-        level: h.level,
-      }));
-      result[shortname] = headings;
+      const byId: { [id: string]: HeadingEntry } = Object.create(null);
+      for (const h of data.headings || []) {
+        byId[h.id] = {
+          id: h.id,
+          href: h.href,
+          title: h.title,
+          number: h.number,
+          level: h.level,
+        };
+      }
+      result[shortname] = byId;
     } catch (error) {
       console.error(`Error reading headings from ${file}:`, error);
     }

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -5,19 +5,19 @@ import { env } from "../../../utils/misc.js";
 import { DataEntry } from "./search.js";
 import { HeadingEntry, HeadingsBySpec } from "./scraper.js";
 
+export type SpecMapGroup = {
+  [specid: string]: {
+    url: string;
+    shortname: string;
+    title: string;
+  };
+};
+
 export class Store {
   version = -1;
   bySpec: { [shortname: string]: DataEntry[] } = {};
   byTerm: { [term: string]: DataEntry[] } = {};
-  specmap: {
-    [group: string]: {
-      [specid: string]: {
-        url: string;
-        shortname: string;
-        title: string;
-      };
-    };
-  } = {};
+  specmap: { [group: string]: SpecMapGroup } = {};
   /** Headings pre-indexed by spec shortname, then by fragment id. */
   headings: HeadingsBySpec = {};
   /** Reverse lookup: shortname → spec title. */
@@ -76,9 +76,7 @@ export class Store {
 
   private *specmapEntries() {
     for (const group of Object.values(this.specmap)) {
-      for (const [specId, entry] of Object.entries(
-        group as unknown as Record<string, { url: string; shortname: string; title: string }>
-      )) {
+      for (const [specId, entry] of Object.entries(group)) {
         yield [specId, entry] as const;
       }
     }
@@ -111,7 +109,7 @@ function buildSpecTitleMap(specmap: Store["specmap"]): Map<string, string> {
   const result = new Map<string, string>();
   // specmap is { current: { [specid]: entry }, snapshot: { [specid]: entry } }
   for (const group of Object.values(specmap)) {
-    for (const entry of Object.values(group as unknown as Record<string, { url: string; shortname: string; title: string }>)) {
+    for (const entry of Object.values(group)) {
       result.set(entry.shortname, entry.title);
     }
   }

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -43,24 +43,7 @@ export class Store {
     id: string,
   ): (HeadingEntry & { specTitle: string }) | null {
     const normalizedSpec = spec.toLowerCase();
-    let specHeadings = this.headings[normalizedSpec];
-    // Fallback: try stripping version suffix (e.g., cssom-view → cssom-view-1)
-    // or adding it via specmap lookup
-    if (!specHeadings) {
-      const stripped = normalizedSpec.replace(/-\d+$/, "");
-      if (stripped !== normalizedSpec) {
-        specHeadings = this.headings[stripped];
-      }
-      if (!specHeadings) {
-        // Try resolving series shortname to versioned via specmap
-        for (const [specId, entry] of this.specmapEntries()) {
-          if (entry.shortname === normalizedSpec || entry.shortname === stripped) {
-            specHeadings = this.headings[specId];
-            if (specHeadings) break;
-          }
-        }
-      }
-    }
+    const specHeadings = this.resolveHeadings(normalizedSpec);
     if (!specHeadings) return null;
 
     const heading = specHeadings[id];
@@ -74,12 +57,28 @@ export class Store {
     };
   }
 
-  private *specmapEntries() {
+  private resolveHeadings(spec: string): Record<string, HeadingEntry> | null {
+    const direct = this.headings[spec];
+    if (direct) return direct;
+
+    // Try stripping version suffix (e.g., cssom-view-1 → cssom-view)
+    const stripped = spec.replace(/-\d+$/, "");
+    if (stripped !== spec) {
+      const unversioned = this.headings[stripped];
+      if (unversioned) return unversioned;
+    }
+
+    // Try resolving series shortname to versioned (or vice versa) via specmap
     for (const group of Object.values(this.specmap)) {
       for (const [specId, entry] of Object.entries(group)) {
-        yield [specId, entry] as const;
+        if (entry.shortname === spec || entry.shortname === stripped) {
+          const resolved = this.headings[specId];
+          if (resolved) return resolved;
+        }
       }
     }
+
+    return null;
   }
 }
 

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -72,8 +72,12 @@ function readJson(filename: string) {
 function readJsonOptional(filename: string) {
   try {
     return readJson(filename);
-  } catch {
-    return {}
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      console.warn(`Optional data file not found: ${filename}`);
+      return {};
+    }
+    throw err;
   }
 }
 
@@ -93,8 +97,11 @@ function indexHeadings(raw: HeadingsBySpec): HeadingsIndex {
 /** Build a shortname → title map from the specmap for O(1) title lookup. */
 function buildSpecTitleMap(specmap: Store["specmap"]): Map<string, string> {
   const result = new Map<string, string>();
-  for (const entry of Object.values(specmap)) {
-    result.set(entry.shortname, entry.title);
+  // specmap is { current: { [specid]: entry }, snapshot: { [specid]: entry } }
+  for (const group of Object.values(specmap)) {
+    for (const entry of Object.values(group as Record<string, { shortname: string; title: string }>)) {
+      result.set(entry.shortname, entry.title);
+    }
   }
   return result;
 }

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -70,11 +70,11 @@ function readJson(filename: string) {
 
 /** Read an optional JSON data file. Returns {} if missing. */
 function readJsonOptional(filename: string) {
-  const DATA_DIR = env("DATA_DIR");
-  const dataFile = path.resolve(DATA_DIR, `./xref/${filename}`);
-  if (!existsSync(dataFile)) return {};
-  const text = readFileSync(dataFile, "utf8");
-  return JSON.parse(text);
+  try {
+    return readJson(filename);
+  } catch {
+    return {}
+  }
 }
 
 /** Index headings arrays by id for O(1) lookup per spec. */

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -1,8 +1,9 @@
 import path from "path";
-import { readFileSync } from "fs";
+import { readFileSync, existsSync } from "fs";
 
 import { env } from "../../../utils/misc.js";
 import { DataEntry } from "./search.js";
+import { HeadingEntry, HeadingsBySpec } from "./scraper.js";
 
 export class Store {
   version = -1;
@@ -15,6 +16,7 @@ export class Store {
       title: string;
     };
   } = {};
+  headings: HeadingsBySpec = {};
 
   constructor() {
     this.fill();
@@ -25,13 +27,33 @@ export class Store {
     this.byTerm = readJson("xref.json");
     this.bySpec = readJson("specs.json");
     this.specmap = readJson("specmap.json");
+    this.headings = readJson("headings.json") || {};
     this.version = Date.now();
+  }
+
+  /** Look up a heading by spec shortname and fragment id. */
+  getHeading(spec: string, id: string): (HeadingEntry & { specTitle: string }) | null {
+    const normalizedSpec = spec.toLowerCase();
+    const headings = this.headings[normalizedSpec];
+    if (!headings) return null;
+
+    const heading = headings.find(h => h.id === id);
+    if (!heading) return null;
+
+    const specInfo = Object.values(this.specmap).find(
+      s => s.shortname === normalizedSpec || s.url?.includes(normalizedSpec),
+    );
+    return {
+      ...heading,
+      specTitle: specInfo?.title || spec,
+    };
   }
 }
 
 function readJson(filename: string) {
   const DATA_DIR = env("DATA_DIR");
   const dataFile = path.resolve(DATA_DIR, `./xref/${filename}`);
+  if (!existsSync(dataFile)) return {};
   const text = readFileSync(dataFile, "utf8");
   return JSON.parse(text);
 }

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -10,10 +10,12 @@ export class Store {
   bySpec: { [shortname: string]: DataEntry[] } = {};
   byTerm: { [term: string]: DataEntry[] } = {};
   specmap: {
-    [specid: string]: {
-      url: string;
-      shortname: string;
-      title: string;
+    [group: string]: {
+      [specid: string]: {
+        url: string;
+        shortname: string;
+        title: string;
+      };
     };
   } = {};
   /** Headings pre-indexed by spec shortname, then by fragment id. */
@@ -41,7 +43,24 @@ export class Store {
     id: string,
   ): (HeadingEntry & { specTitle: string }) | null {
     const normalizedSpec = spec.toLowerCase();
-    const specHeadings = this.headings[normalizedSpec];
+    let specHeadings = this.headings[normalizedSpec];
+    // Fallback: try stripping version suffix (e.g., cssom-view → cssom-view-1)
+    // or adding it via specmap lookup
+    if (!specHeadings) {
+      const stripped = normalizedSpec.replace(/-\d+$/, "");
+      if (stripped !== normalizedSpec) {
+        specHeadings = this.headings[stripped];
+      }
+      if (!specHeadings) {
+        // Try resolving series shortname to versioned via specmap
+        for (const [specId, entry] of this.specmapEntries()) {
+          if (entry.shortname === normalizedSpec || entry.shortname === stripped) {
+            specHeadings = this.headings[specId];
+            if (specHeadings) break;
+          }
+        }
+      }
+    }
     if (!specHeadings) return null;
 
     const heading = specHeadings[id];
@@ -49,8 +68,20 @@ export class Store {
 
     return {
       ...heading,
-      specTitle: this.specTitleByShortname.get(normalizedSpec) || spec,
+      specTitle: this.specTitleByShortname.get(normalizedSpec)
+        || this.specTitleByShortname.get(normalizedSpec.replace(/-\d+$/, ""))
+        || spec,
     };
+  }
+
+  private *specmapEntries() {
+    for (const group of Object.values(this.specmap)) {
+      for (const [specId, entry] of Object.entries(
+        group as unknown as Record<string, { url: string; shortname: string; title: string }>
+      )) {
+        yield [specId, entry] as const;
+      }
+    }
   }
 }
 
@@ -80,7 +111,7 @@ function buildSpecTitleMap(specmap: Store["specmap"]): Map<string, string> {
   const result = new Map<string, string>();
   // specmap is { current: { [specid]: entry }, snapshot: { [specid]: entry } }
   for (const group of Object.values(specmap)) {
-    for (const entry of Object.values(group as Record<string, { shortname: string; title: string }>)) {
+    for (const entry of Object.values(group as unknown as Record<string, { url: string; shortname: string; title: string }>)) {
       result.set(entry.shortname, entry.title);
     }
   }

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -5,6 +5,11 @@ import { env } from "../../../utils/misc.js";
 import { DataEntry } from "./search.js";
 import { HeadingEntry, HeadingsBySpec } from "./scraper.js";
 
+/** Headings indexed by id for O(1) lookup. */
+type HeadingsIndex = {
+  [shortname: string]: { [id: string]: HeadingEntry };
+};
+
 export class Store {
   version = -1;
   bySpec: { [shortname: string]: DataEntry[] } = {};
@@ -16,7 +21,10 @@ export class Store {
       title: string;
     };
   } = {};
-  headings: HeadingsBySpec = {};
+  /** Headings indexed by spec shortname, then by fragment id. */
+  headings: HeadingsIndex = {};
+  /** Reverse lookup: shortname → spec title. */
+  private specTitleByShortname: { [shortname: string]: string } = {};
 
   constructor() {
     this.fill();
@@ -27,33 +35,68 @@ export class Store {
     this.byTerm = readJson("xref.json");
     this.bySpec = readJson("specs.json");
     this.specmap = readJson("specmap.json");
-    this.headings = readJson("headings.json") || {};
+    const rawHeadings: HeadingsBySpec = readJsonOptional("headings.json");
+    this.headings = indexHeadings(rawHeadings);
+    this.specTitleByShortname = buildSpecTitleMap(this.specmap);
     this.version = Date.now();
   }
 
   /** Look up a heading by spec shortname and fragment id. */
-  getHeading(spec: string, id: string): (HeadingEntry & { specTitle: string }) | null {
+  getHeading(
+    spec: string,
+    id: string,
+  ): (HeadingEntry & { specTitle: string }) | null {
     const normalizedSpec = spec.toLowerCase();
-    const headings = this.headings[normalizedSpec];
-    if (!headings) return null;
+    const specHeadings = this.headings[normalizedSpec];
+    if (!specHeadings) return null;
 
-    const heading = headings.find(h => h.id === id);
+    const heading = specHeadings[id];
     if (!heading) return null;
 
-    const specInfo = Object.values(this.specmap).find(
-      s => s.shortname === normalizedSpec || s.url?.includes(normalizedSpec),
-    );
     return {
       ...heading,
-      specTitle: specInfo?.title || spec,
+      specTitle: this.specTitleByShortname[normalizedSpec] || spec,
     };
   }
 }
 
+/** Read a required JSON data file. Throws if missing. */
 function readJson(filename: string) {
+  const DATA_DIR = env("DATA_DIR");
+  const dataFile = path.resolve(DATA_DIR, `./xref/${filename}`);
+  const text = readFileSync(dataFile, "utf8");
+  return JSON.parse(text);
+}
+
+/** Read an optional JSON data file. Returns {} if missing. */
+function readJsonOptional(filename: string) {
   const DATA_DIR = env("DATA_DIR");
   const dataFile = path.resolve(DATA_DIR, `./xref/${filename}`);
   if (!existsSync(dataFile)) return {};
   const text = readFileSync(dataFile, "utf8");
   return JSON.parse(text);
+}
+
+/** Index headings arrays by id for O(1) lookup per spec. */
+function indexHeadings(raw: HeadingsBySpec): HeadingsIndex {
+  const indexed: HeadingsIndex = Object.create(null);
+  for (const [shortname, headings] of Object.entries(raw)) {
+    const byId: { [id: string]: HeadingEntry } = Object.create(null);
+    for (const h of headings) {
+      byId[h.id] = h;
+    }
+    indexed[shortname] = byId;
+  }
+  return indexed;
+}
+
+/** Build a shortname → title map from the specmap for O(1) title lookup. */
+function buildSpecTitleMap(
+  specmap: Store["specmap"],
+): { [shortname: string]: string } {
+  const result: { [shortname: string]: string } = Object.create(null);
+  for (const entry of Object.values(specmap)) {
+    result[entry.shortname] = entry.title;
+  }
+  return result;
 }

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -24,7 +24,7 @@ export class Store {
   /** Headings indexed by spec shortname, then by fragment id. */
   headings: HeadingsIndex = {};
   /** Reverse lookup: shortname → spec title. */
-  private specTitleByShortname: { [shortname: string]: string } = {};
+  private specTitleByShortname: Map<string, string> = new Map();
 
   constructor() {
     this.fill();
@@ -55,7 +55,7 @@ export class Store {
 
     return {
       ...heading,
-      specTitle: this.specTitleByShortname[normalizedSpec] || spec,
+      specTitle: this.specTitleByShortname.get(normalizedSpec) || spec,
     };
   }
 }
@@ -91,12 +91,10 @@ function indexHeadings(raw: HeadingsBySpec): HeadingsIndex {
 }
 
 /** Build a shortname → title map from the specmap for O(1) title lookup. */
-function buildSpecTitleMap(
-  specmap: Store["specmap"],
-): { [shortname: string]: string } {
-  const result: { [shortname: string]: string } = Object.create(null);
+function buildSpecTitleMap(specmap: Store["specmap"]): Map<string, string> {
+  const result = new Map<string, string>();
   for (const entry of Object.values(specmap)) {
-    result[entry.shortname] = entry.title;
+    result.set(entry.shortname, entry.title);
   }
   return result;
 }

--- a/routes/xref/lib/store.ts
+++ b/routes/xref/lib/store.ts
@@ -1,14 +1,9 @@
 import path from "path";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync } from "fs";
 
 import { env } from "../../../utils/misc.js";
 import { DataEntry } from "./search.js";
 import { HeadingEntry, HeadingsBySpec } from "./scraper.js";
-
-/** Headings indexed by id for O(1) lookup. */
-type HeadingsIndex = {
-  [shortname: string]: { [id: string]: HeadingEntry };
-};
 
 export class Store {
   version = -1;
@@ -21,8 +16,8 @@ export class Store {
       title: string;
     };
   } = {};
-  /** Headings indexed by spec shortname, then by fragment id. */
-  headings: HeadingsIndex = {};
+  /** Headings pre-indexed by spec shortname, then by fragment id. */
+  headings: HeadingsBySpec = {};
   /** Reverse lookup: shortname → spec title. */
   private specTitleByShortname: Map<string, string> = new Map();
 
@@ -35,8 +30,7 @@ export class Store {
     this.byTerm = readJson("xref.json");
     this.bySpec = readJson("specs.json");
     this.specmap = readJson("specmap.json");
-    const rawHeadings: HeadingsBySpec = readJsonOptional("headings.json");
-    this.headings = indexHeadings(rawHeadings);
+    this.headings = readJsonOptional("headings.json");
     this.specTitleByShortname = buildSpecTitleMap(this.specmap);
     this.version = Date.now();
   }
@@ -79,19 +73,6 @@ function readJsonOptional(filename: string) {
     }
     throw err;
   }
-}
-
-/** Index headings arrays by id for O(1) lookup per spec. */
-function indexHeadings(raw: HeadingsBySpec): HeadingsIndex {
-  const indexed: HeadingsIndex = Object.create(null);
-  for (const [shortname, headings] of Object.entries(raw)) {
-    const byId: { [id: string]: HeadingEntry } = Object.create(null);
-    for (const h of headings) {
-      byId[h.id] = h;
-    }
-    indexed[shortname] = byId;
-  }
-  return indexed;
 }
 
 /** Build a shortname → title map from the specmap for O(1) title lookup. */

--- a/routes/xref/update.ts
+++ b/routes/xref/update.ts
@@ -59,5 +59,7 @@ function hasRelevantUpdate(commits: Commit[]) {
   const changedFiles = commits
     .map(commit => [commit.added, commit.removed, commit.modified])
     .flat(2);
-  return changedFiles.some(file => file?.startsWith("ed/dfns/"));
+  return changedFiles.some(
+    file => file?.startsWith("ed/dfns/") || file?.startsWith("ed/headings/"),
+  );
 }

--- a/routes/xref/update.ts
+++ b/routes/xref/update.ts
@@ -58,5 +58,7 @@ function hasRelevantUpdate(commits: Commit[]) {
   const changedFiles = commits
     .map(commit => [commit.added, commit.removed, commit.modified])
     .flat(2);
-  return changedFiles.some(file => file?.startsWith("ed/dfns/"));
+  return changedFiles.some(
+    file => file?.startsWith("ed/dfns/") || file?.startsWith("ed/headings/"),
+  );
 }


### PR DESCRIPTION
Extends the xref infrastructure to read and serve section heading data from WebRef's `ed/headings/` directory. This enables ReSpec's `[[[SPEC#id]]]` syntax to display actual heading text instead of just the spec title.

## New endpoint

`POST /xref/search/headings` — looks up section headings by spec shortname and fragment id. Request body: `{ queries: [{ spec, id }] }`. Response: `{ result: [{ spec, id, title, number, href, level, specTitle }] }`.

Capped at 1000 queries per request. Empty spec/id values are rejected with 400.

## Changes

- **scraper.ts**: reads `ed/headings/*.json` during update, writes `headings.json`. Shortname derived from filename (webref doesn't include it in the JSON).
- **store.ts**: loads headings, indexes by spec+id for O(1) lookup. `buildSpecTitleMap` iterates the nested `{current, snapshot}` specmap structure to resolve human-readable spec titles. `readJsonOptional` only catches ENOENT (not all errors).
- **headings.post.ts**: route handler with input validation (array check, type check, empty-string check, 1000-query cap)
- **index.ts**: registers `POST /xref/search/headings` with CORS + 1MB body limit
- **update.ts**: also triggers on `ed/headings/` changes in webref webhook

## Context

- Requested by @sidvishnoi in speced/respec#5146 review
- Data source: [w3c/webref](https://github.com/w3c/webref/tree/main/ed/headings) headings data
- Companion change needed in ReSpec's `src/core/inlines.js` to consume this API