### PR TITLE
fix(xref): start query on original term, instead of lowercase

### DIFF
--- a/routes/xref/lib/search.ts
+++ b/routes/xref/lib/search.ts
@@ -144,7 +144,8 @@ function getTermVariations(query: Query) {
   if (shouldTreatAsConcept) {
     const term = inputTerm.toLowerCase();
     return (function* () {
-      yield term;
+      yield inputTerm;
+      if (term !== inputTerm) yield term;
       yield* textVariations(term);
     })();
   } else {

--- a/tests/routes/xref/lib/data-by-term.js
+++ b/tests/routes/xref/lib/data-by-term.js
@@ -262,6 +262,24 @@ export default {
       normative: false,
     },
   ],
+  foreignObject: [
+    {
+      type: "element",
+      spec: "svg2",
+      shortname: "svg",
+      status: "current",
+      uri: "embedded.html#elementdef-foreignObject",
+    },
+  ],
+  clipPath: [
+    {
+      type: "element",
+      spec: "svg2",
+      shortname: "svg",
+      status: "current",
+      uri: "masking.html#elementdef-clipPath",
+    },
+  ],
   "user agents": [
     {
       type: "dfn",

--- a/tests/routes/xref/lib/search.test.js
+++ b/tests/routes/xref/lib/search.test.js
@@ -162,11 +162,23 @@ describe("xref - search", () => {
       expect(
         search({ term: "foreignObject", types: ["element", "dfn"] }),
       ).toEqual(foreignObject);
+      expect(
+        search({ term: "foreignObject", types: ["_CONCEPT_"] }),
+      ).toEqual(foreignObject);
+      expect(
+        search({ term: "foreignObject", types: ["element", "dfn"] }),
+      ).toEqual(foreignObject);
 
       const clipPath = [{ uri: "masking.html#elementdef-clipPath" }];
       expect(search({ term: "clipPath", types: ["element"] })).toEqual(
         clipPath,
       );
+      expect(search({ term: "clipPath", types: ["_CONCEPT_"] })).toEqual(
+        clipPath,
+      );
+      expect(
+        search({ term: "clipPath", types: ["element", "dfn"] }),
+      ).toEqual(clipPath);
       expect(search({ term: "clipPath", types: ["_CONCEPT_"] })).toEqual(
         clipPath,
       );

--- a/tests/routes/xref/lib/search.test.js
+++ b/tests/routes/xref/lib/search.test.js
@@ -148,6 +148,32 @@ describe("xref - search", () => {
         baselineInterface,
       );
     });
+
+    it("preserves case for element-type queries", () => {
+      const foreignObject = [
+        { uri: "embedded.html#elementdef-foreignObject" },
+      ];
+      expect(
+        search({ term: "foreignObject", types: ["element"] }),
+      ).toEqual(foreignObject);
+      expect(
+        search({ term: "foreignObject", types: ["_CONCEPT_"] }),
+      ).toEqual(foreignObject);
+      expect(
+        search({ term: "foreignObject", types: ["element", "dfn"] }),
+      ).toEqual(foreignObject);
+
+      const clipPath = [{ uri: "masking.html#elementdef-clipPath" }];
+      expect(search({ term: "clipPath", types: ["element"] })).toEqual(
+        clipPath,
+      );
+      expect(search({ term: "clipPath", types: ["_CONCEPT_"] })).toEqual(
+        clipPath,
+      );
+      expect(
+        search({ term: "clipPath", types: ["element", "dfn"] }),
+      ).toEqual(clipPath);
+    });
   });
 
   describe("filter@specs", () => {

--- a/tests/routes/xref/lib/search.test.js
+++ b/tests/routes/xref/lib/search.test.js
@@ -168,11 +168,23 @@ describe("xref - search", () => {
       expect(
         search({ term: "foreignObject", types: ["element", "dfn"] }),
       ).toEqual(foreignObject);
+      expect(
+        search({ term: "foreignObject", types: ["_CONCEPT_"] }),
+      ).toEqual(foreignObject);
+      expect(
+        search({ term: "foreignObject", types: ["element", "dfn"] }),
+      ).toEqual(foreignObject);
 
       const clipPath = [{ uri: "masking.html#elementdef-clipPath" }];
       expect(search({ term: "clipPath", types: ["element"] })).toEqual(
         clipPath,
       );
+      expect(search({ term: "clipPath", types: ["_CONCEPT_"] })).toEqual(
+        clipPath,
+      );
+      expect(
+        search({ term: "clipPath", types: ["element", "dfn"] }),
+      ).toEqual(clipPath);
       expect(search({ term: "clipPath", types: ["_CONCEPT_"] })).toEqual(
         clipPath,
       );

--- a/tests/routes/xref/lib/search.test.js
+++ b/tests/routes/xref/lib/search.test.js
@@ -16,8 +16,9 @@ const search = (query, options) => {
 };
 
 describe("xref - search", () => {
+  beforeEach(() => cache.clear());
+
   describe("options", () => {
-    beforeEach(() => cache.clear());
 
     describe("query", () => {
       it("adds query back to response if requested", () => {
@@ -162,35 +163,11 @@ describe("xref - search", () => {
       expect(
         search({ term: "foreignObject", types: ["element", "dfn"] }),
       ).toEqual(foreignObject);
-      expect(
-        search({ term: "foreignObject", types: ["_CONCEPT_"] }),
-      ).toEqual(foreignObject);
-      expect(
-        search({ term: "foreignObject", types: ["element", "dfn"] }),
-      ).toEqual(foreignObject);
-      expect(
-        search({ term: "foreignObject", types: ["_CONCEPT_"] }),
-      ).toEqual(foreignObject);
-      expect(
-        search({ term: "foreignObject", types: ["element", "dfn"] }),
-      ).toEqual(foreignObject);
 
       const clipPath = [{ uri: "masking.html#elementdef-clipPath" }];
       expect(search({ term: "clipPath", types: ["element"] })).toEqual(
         clipPath,
       );
-      expect(search({ term: "clipPath", types: ["_CONCEPT_"] })).toEqual(
-        clipPath,
-      );
-      expect(
-        search({ term: "clipPath", types: ["element", "dfn"] }),
-      ).toEqual(clipPath);
-      expect(search({ term: "clipPath", types: ["_CONCEPT_"] })).toEqual(
-        clipPath,
-      );
-      expect(
-        search({ term: "clipPath", types: ["element", "dfn"] }),
-      ).toEqual(clipPath);
       expect(search({ term: "clipPath", types: ["_CONCEPT_"] })).toEqual(
         clipPath,
       );


### PR DESCRIPTION
## Summary
- Fixed camelCase SVG elements (e.g., `foreignObject`, `clipPath`) not being found in xref search
- Root cause: `getTermVariations()` lowercased element-type queries because `element` is in `CONCEPT_TYPES`
- Fix: exclude element-type queries from concept lowercasing while preserving it for other concept types (dfn, event, permission)
- Added tests with `foreignObject` and `clipPath` test data

Closes #365