### PR TITLE
fix: drop dotenv dependency, use Node 24 built-in --env-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .env
 .vscode
 data
-ecosystem.config.cjs
 node_modules
 package-lock.json
 yarn.lock

--- a/app.ts
+++ b/app.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import path from "path";
 
 import express from "express";

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,14 @@
+// @ts-check
+"use strict";
+
+/** @type {import("pm2").StartOptions} */
+const app = {
+  name: "respec-web-services",
+  script: "./build/app.js",
+  node_args: "--env-file-if-exists=.env --enable-source-maps",
+  env_production: {
+    NODE_ENV: "production",
+  },
+};
+
+module.exports = { apps: [app] };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "chalk": "^5.6.2",
     "compression": "^1.8.1",
     "cors": "^2.8.6",
-    "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "express-rate-limit": "^8.4.0",
     "helmet": "^8.1.0",
@@ -28,11 +27,11 @@
     "build": "tsc",
     "build:watch": "tsc -w",
     "prestart": "npm run update-data-sources && npm run regenerate-docs",
-    "start": "node --enable-source-maps build/app.js",
+    "start": "node --env-file=.env --enable-source-maps build/app.js",
     "start:server": "pm2 start ecosystem.config.cjs --env production",
     "test": "jasmine --config=tests/jasmine.json",
     "regenerate-docs": "node --trace-warnings ./build/scripts/regenerate-docs.js",
-    "update-data-sources": "node build/scripts/update-data-sources.js"
+    "update-data-sources": "node --env-file=.env build/scripts/update-data-sources.js"
   },
   "packageManager": "pnpm@9.8.0",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "compression": "^1.8.1",
     "cors": "^2.8.6",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.4.0",
+    "express-rate-limit": "^8.4.1",
     "helmet": "^8.1.0",
     "morgan": "^1.10.1",
     "nanoid": "^5.1.9",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "build": "tsc",
     "build:watch": "tsc -w",
     "prestart": "npm run update-data-sources && npm run regenerate-docs",
-    "start": "node --env-file=.env --enable-source-maps build/app.js",
-    "start:server": "pm2 start ecosystem.config.cjs --env production",
+    "start": "node --env-file-if-exists=.env --enable-source-maps build/app.js",
+    "start:server": "pm2 start ecosystem.config.cjs --env production --node-args=\"--env-file-if-exists=.env\"",
     "test": "jasmine --config=tests/jasmine.json",
     "regenerate-docs": "node --trace-warnings ./build/scripts/regenerate-docs.js",
-    "update-data-sources": "node --env-file=.env build/scripts/update-data-sources.js"
+    "update-data-sources": "node --env-file-if-exists=.env build/scripts/update-data-sources.js"
   },
   "packageManager": "pnpm@9.8.0",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:watch": "tsc -w",
     "prestart": "npm run update-data-sources && npm run regenerate-docs",
     "start": "node --env-file-if-exists=.env --enable-source-maps build/app.js",
-    "start:server": "pm2 start ecosystem.config.cjs --env production --node-args=\"--env-file-if-exists=.env\"",
+    "start:server": "pm2 start ecosystem.config.cjs --env production",
     "test": "jasmine --config=tests/jasmine.json",
     "regenerate-docs": "node --trace-warnings ./build/scripts/regenerate-docs.js",
     "update-data-sources": "node --env-file-if-exists=.env build/scripts/update-data-sources.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,15 +20,12 @@ importers:
       cors:
         specifier: ^2.8.6
         version: 2.8.6
-      dotenv:
-        specifier: ^17.4.2
-        version: 17.4.2
       express:
         specifier: ^5.2.1
         version: 5.2.1
       express-rate-limit:
         specifier: ^8.4.0
-        version: 8.4.0(express@5.2.1)
+        version: 8.4.1(express@5.2.1)
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
@@ -265,10 +262,6 @@ packages:
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
-  dotenv@17.4.2:
-    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
-    engines: {node: '>=12'}
-
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -303,8 +296,8 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  express-rate-limit@8.4.0:
-    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -844,8 +837,6 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
 
-  dotenv@17.4.2: {}
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -870,7 +861,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  express-rate-limit@8.4.0(express@5.2.1):
+  express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       express-rate-limit:
-        specifier: ^8.4.0
+        specifier: ^8.4.1
         version: 8.4.1(express@5.2.1)
       helmet:
         specifier: ^8.1.0

--- a/scripts/update-data-sources.ts
+++ b/scripts/update-data-sources.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { mkdir } from "fs/promises";
 import { env } from "../utils/misc.js";
 import caniuse from "../routes/caniuse/lib/scraper.js";

--- a/scripts/update-w3c-groups-list.ts
+++ b/scripts/update-w3c-groups-list.ts
@@ -6,8 +6,6 @@
 import path from "path";
 import { writeFile, mkdir } from "fs/promises";
 
-import "dotenv/config";
-
 import { env } from "../utils/misc.js";
 
 const DATA_DIR = env("DATA_DIR");

--- a/scripts/update-w3c-groups-list.ts
+++ b/scripts/update-w3c-groups-list.ts
@@ -1,6 +1,8 @@
 /**
- * Run this script occasionally to update {@link {DATA_DIR}/w3c/groups.json}
- * with new group shortnames and IDs.
+ * Updates {@link {DATA_DIR}/w3c/groups.json} with current group shortnames and IDs.
+ *
+ * Standalone: node --env-file-if-exists=.env build/scripts/update-w3c-groups-list.js
+ * Via npm:    npm run update-data-sources
  */
 
 import path from "path";


### PR DESCRIPTION
## Summary
- Removed `dotenv` dependency (Node 24 has built-in `--env-file` support)
- Removed `import "dotenv/config"` from `app.ts`, `scripts/update-data-sources.ts`, and `scripts/update-w3c-groups-list.ts`
- Added `--env-file=.env` to `start` and `update-data-sources` npm scripts

Closes #396