### PR TITLE
fix(xref/ui): disambiguate overloaded method signatures in search results

### DIFF
--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -145,8 +145,8 @@ function renderResults(entries, query) {
   }
 
   // Detect overloaded IDL entries that would produce identical citations.
-  // Build a map of citation key -> list of entries to find duplicates.
-  const overloadedURIs = detectOverloadedEntries(entries, term);
+  // Build a set of "uri|forContext" pairs for entries that need disambiguation.
+  const overloadedPairs = detectOverloadedEntries(entries, term);
 
   let html = '';
   for (const entry of entries) {
@@ -156,9 +156,8 @@ function renderResults(entries, query) {
     const specInfo = metadata.specs[entry.status][entry.spec];
     const link = new URL(entry.uri, specInfo.url).href;
     const title = escapeHTML(specInfo.title);
-    const isOverloaded = overloadedURIs.has(entry.uri);
     const cite = metadata.types.idl.has(entry.type)
-      ? howToCiteIDL(citeTerm, entry, isOverloaded)
+      ? howToCiteIDL(citeTerm, entry, overloadedPairs)
       : metadata.types.markup.has(entry.type)
         ? howToCiteMarkup(citeTerm, entry)
         : metadata.types.css.has(entry.type) ||
@@ -179,7 +178,9 @@ function renderResults(entries, query) {
 
 /**
  * Detects IDL entries that would produce identical citations (overloaded
- * methods/constructors). Returns a Set of URIs that need disambiguation.
+ * methods/constructors). Returns a Set of "uri|forContext" keys for entries
+ * that need disambiguation. Entries without a `for` list use an empty string
+ * as the forContext part.
  */
 function detectOverloadedEntries(entries, term) {
   const citationGroups = new Map();
@@ -190,26 +191,33 @@ function detectOverloadedEntries(entries, term) {
     const forList = entry.for || [];
     // Group per individual rendered citation (one per `f`), so overlapping
     // `for` contexts across entries are correctly detected as ambiguous.
-    const keys =
-      forList.length > 0
-        ? forList.map(f => `${f}|${term}|${specKey}|${statusKey}`)
-        : [`|${term}|${specKey}|${statusKey}`];
-    for (const key of keys) {
+    if (forList.length > 0) {
+      for (const f of forList) {
+        const key = `${f}|${term}|${specKey}|${statusKey}`;
+        const group = citationGroups.get(key) ?? [];
+        if (!group.length) citationGroups.set(key, group);
+        group.push({ entry, f });
+      }
+    } else {
+      const key = `|${term}|${specKey}|${statusKey}`;
       const group = citationGroups.get(key) ?? [];
       if (!group.length) citationGroups.set(key, group);
-      group.push(entry);
+      group.push({ entry, f: '' });
     }
   }
-  const overloadedURIs = new Set();
+  // Build a Set of "uri|forContext" strings for ambiguous (entry, f) pairs.
+  const overloadedPairs = new Set();
   for (const group of citationGroups.values()) {
     if (group.length > 1) {
-      group.forEach(entry => overloadedURIs.add(entry.uri));
+      for (const { entry, f } of group) {
+        overloadedPairs.add(`${entry.uri}|${f}`);
+      }
     }
   }
-  return overloadedURIs;
+  return overloadedPairs;
 }
 
-function howToCiteIDL(term, entry, isOverloaded = false) {
+function howToCiteIDL(term, entry, overloadedPairs = null) {
   const { type, for: forList } = entry;
   const safeTerm = escapeHTML(term);
   if (forList) {
@@ -217,7 +225,7 @@ function howToCiteIDL(term, entry, isOverloaded = false) {
       .map(f => {
         const safeF = escapeHTML(f);
         let displayTerm = type === 'enum-value' ? `"${safeTerm}"` : safeTerm;
-        if (isOverloaded) {
+        if (overloadedPairs?.has(`${entry.uri}|${f}`)) {
           const hint = extractOverloadHint(entry.uri, f, term);
           if (hint) {
             displayTerm = displayTerm.replace('()', `(${escapeHTML(hint)})`);
@@ -237,7 +245,7 @@ function howToCiteIDL(term, entry, isOverloaded = false) {
     default:
       cite = `{{${safeTerm}}}`;
   }
-  if (isOverloaded) {
+  if (overloadedPairs?.has(`${entry.uri}|`)) {
     const hint = extractOverloadHint(entry.uri, null, term);
     if (hint) {
       cite = cite.replace('()', `(${escapeHTML(hint)})`);

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -144,6 +144,10 @@ function renderResults(entries, query) {
     return;
   }
 
+  // Detect overloaded IDL entries that would produce identical citations.
+  // Build a map of citation key -> list of entries to find duplicates.
+  const overloadedURIs = detectOverloadedEntries(entries, term);
+
   let html = '';
   for (const entry of entries) {
     // Use the canonical matched term when available (case-insensitive fallback
@@ -152,8 +156,9 @@ function renderResults(entries, query) {
     const specInfo = metadata.specs[entry.status][entry.spec];
     const link = new URL(entry.uri, specInfo.url).href;
     const title = escapeHTML(specInfo.title);
+    const isOverloaded = overloadedURIs.has(entry.uri);
     const cite = metadata.types.idl.has(entry.type)
-      ? howToCiteIDL(citeTerm, entry)
+      ? howToCiteIDL(citeTerm, entry, isOverloaded)
       : metadata.types.markup.has(entry.type)
         ? howToCiteMarkup(citeTerm, entry)
         : metadata.types.css.has(entry.type) ||
@@ -172,7 +177,30 @@ function renderResults(entries, query) {
   output.innerHTML = html;
 }
 
-function howToCiteIDL(term, entry) {
+/**
+ * Detects IDL entries that would produce identical citations (overloaded
+ * methods/constructors). Returns a Set of URIs that need disambiguation.
+ */
+function detectOverloadedEntries(entries, term) {
+  const citationGroups = new Map();
+  for (const entry of entries) {
+    if (!metadata.types.idl.has(entry.type)) continue;
+    const forKey = (entry.for || []).join(',');
+    const key = `${entry.type}|${forKey}|${term}`;
+    const group = citationGroups.get(key) ?? [];
+    if (!group.length) citationGroups.set(key, group);
+    group.push(entry);
+  }
+  const overloadedURIs = new Set();
+  for (const group of citationGroups.values()) {
+    if (group.length > 1) {
+      group.forEach(entry => overloadedURIs.add(entry.uri));
+    }
+  }
+  return overloadedURIs;
+}
+
+function howToCiteIDL(term, entry, isOverloaded = false) {
   const { type, for: forList } = entry;
   const safeTerm = escapeHTML(term);
   if (forList) {
@@ -180,18 +208,75 @@ function howToCiteIDL(term, entry) {
       .map(f => {
         const safeF = escapeHTML(f);
         const termPart = type === 'enum-value' ? `"${safeTerm}"` : safeTerm;
-        return `{{${safeF}/${safeTerm ? termPart : '""'}}}`;
+        let cite = `{{${safeF}/${safeTerm ? termPart : '""'}}}`;
+        if (isOverloaded) {
+          const hint = extractOverloadHint(entry.uri, f, term);
+          if (hint) {
+            cite += ` <small>(${escapeHTML(hint)})</small>`;
+          }
+        }
+        return cite;
       })
       .join('<br>');
   }
+  let cite;
   switch (type) {
     case 'exception':
       if (!exceptionExceptions.has(term)) {
-        return `{{"${safeTerm}"}}`;
+        cite = `{{"${safeTerm}"}}`;
+        break;
       }
     default:
-      return `{{${safeTerm}}}`;
+      cite = `{{${safeTerm}}}`;
   }
+  if (isOverloaded) {
+    const hint = extractOverloadHint(entry.uri, null, term);
+    if (hint) {
+      cite += ` <small>(${escapeHTML(hint)})</small>`;
+    }
+  }
+  return cite;
+}
+
+/**
+ * Extracts a human-readable overload hint from a URI fragment.
+ *
+ * URI fragments for WebIDL definitions follow the pattern:
+ *   #dom-<interface>-<method>-<param1>-<param2>-...
+ *
+ * For example:
+ *   #dom-window-postmessage-message-targetorigin-transfer
+ *   #dom-window-postmessage-message-options
+ *
+ * This function strips the known prefix (interface + method) and returns
+ * the remaining parts as a parameter list, e.g. "message, targetorigin, transfer".
+ */
+function extractOverloadHint(uri, forContext, term) {
+  if (!uri) return '';
+  const hash = uri.includes('#') ? uri.split('#')[1] : uri;
+  if (!hash) return '';
+
+  const parts = hash.toLowerCase().split('-');
+
+  // Build the prefix to strip: typically "dom", interface, method
+  const prefixParts = ['dom'];
+  if (forContext) {
+    prefixParts.push(...forContext.toLowerCase().split('-'));
+  }
+  const cleanTerm = term.replace(/\(.*\)$/, '').toLowerCase();
+  if (cleanTerm) {
+    prefixParts.push(...cleanTerm.split('-'));
+  }
+
+  const matches =
+    prefixParts.length <= parts.length &&
+    prefixParts.every((p, i) => parts[i] === p);
+
+  if (matches && prefixParts.length < parts.length) {
+    return parts.slice(prefixParts.length).join(', ');
+  }
+
+  return '';
 }
 
 function howToCiteMarkup(term, entry) {

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -185,13 +185,20 @@ function detectOverloadedEntries(entries, term) {
   const citationGroups = new Map();
   for (const entry of entries) {
     if (!metadata.types.idl.has(entry.type)) continue;
-    const forKey = (entry.for || []).join(',');
     const specKey = entry.spec || '';
     const statusKey = entry.status || '';
-    const key = `${entry.type}|${forKey}|${term}|${specKey}|${statusKey}`;
-    const group = citationGroups.get(key) ?? [];
-    if (!group.length) citationGroups.set(key, group);
-    group.push(entry);
+    const forList = entry.for || [];
+    // Group per individual rendered citation (one per `f`), so overlapping
+    // `for` contexts across entries are correctly detected as ambiguous.
+    const keys =
+      forList.length > 0
+        ? forList.map(f => `${f}|${term}|${specKey}|${statusKey}`)
+        : [`|${term}|${specKey}|${statusKey}`];
+    for (const key of keys) {
+      const group = citationGroups.get(key) ?? [];
+      if (!group.length) citationGroups.set(key, group);
+      group.push(entry);
+    }
   }
   const overloadedURIs = new Set();
   for (const group of citationGroups.values()) {
@@ -257,7 +264,8 @@ function extractOverloadHint(uri, forContext, term) {
   const hash = uri.includes('#') ? uri.split('#')[1] : uri;
   if (!hash) return '';
 
-  const parts = hash.toLowerCase().split('-');
+  const originalParts = hash.split('-');
+  const lowerParts = hash.toLowerCase().split('-');
 
   // Build the prefix to strip: typically "dom", interface, method
   const prefixParts = ['dom'];
@@ -270,11 +278,11 @@ function extractOverloadHint(uri, forContext, term) {
   }
 
   const matches =
-    prefixParts.length <= parts.length &&
-    prefixParts.every((p, i) => parts[i] === p);
+    prefixParts.length <= lowerParts.length &&
+    prefixParts.every((p, i) => lowerParts[i] === p);
 
-  if (matches && prefixParts.length < parts.length) {
-    return parts.slice(prefixParts.length).join(', ');
+  if (matches && prefixParts.length < lowerParts.length) {
+    return originalParts.slice(prefixParts.length).join(', ');
   }
 
   return '';

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -207,15 +207,14 @@ function howToCiteIDL(term, entry, isOverloaded = false) {
     return forList
       .map(f => {
         const safeF = escapeHTML(f);
-        const termPart = type === 'enum-value' ? `"${safeTerm}"` : safeTerm;
-        let cite = `{{${safeF}/${safeTerm ? termPart : '""'}}}`;
+        let displayTerm = type === 'enum-value' ? `"${safeTerm}"` : safeTerm;
         if (isOverloaded) {
           const hint = extractOverloadHint(entry.uri, f, term);
           if (hint) {
-            cite += ` <small>(${escapeHTML(hint)})</small>`;
+            displayTerm = displayTerm.replace('()', `(${escapeHTML(hint)})`);
           }
         }
-        return cite;
+        return `{{${safeF}/${displayTerm ? displayTerm : '""'}}}`;
       })
       .join('<br>');
   }
@@ -232,7 +231,7 @@ function howToCiteIDL(term, entry, isOverloaded = false) {
   if (isOverloaded) {
     const hint = extractOverloadHint(entry.uri, null, term);
     if (hint) {
-      cite += ` <small>(${escapeHTML(hint)})</small>`;
+      cite = cite.replace('()', `(${escapeHTML(hint)})`);
     }
   }
   return cite;

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -186,7 +186,9 @@ function detectOverloadedEntries(entries, term) {
   for (const entry of entries) {
     if (!metadata.types.idl.has(entry.type)) continue;
     const forKey = (entry.for || []).join(',');
-    const key = `${entry.type}|${forKey}|${term}`;
+    const specKey = entry.spec || '';
+    const statusKey = entry.status || '';
+    const key = `${entry.type}|${forKey}|${term}|${specKey}|${statusKey}`;
     const group = citationGroups.get(key) ?? [];
     if (!group.length) citationGroups.set(key, group);
     group.push(entry);


### PR DESCRIPTION
Detect IDL entries that would render the same citation (overloaded methods) and embed their parameters from the URI fragment, e.g. {{Window/postMessage(message, options)}}. Reduced from #495 to just this and stacked on the escaping PR #528; also drops Map.prototype.getOrInsert (Baseline only since Feb 2026). Closes #383.