### PR TITLE
feat: add GitHub Actions workflow to auto-update W3C groups list

### DIFF
--- a/.github/workflows/update-groups.yml
+++ b/.github/workflows/update-groups.yml
@@ -1,0 +1,33 @@
+name: Update W3C groups list
+on:
+  schedule:
+    - cron: '23 3 * * 1' # Weekly on Monday at 03:23 UTC
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: node build/scripts/update-w3c-groups-list.js
+        env:
+          DATA_DIR: ${{ github.workspace }}/data
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add --force data/w3c/groups.json
+          git diff --staged --quiet || git commit -m "chore: auto-update W3C groups list"
+          git push


### PR DESCRIPTION
## Summary
- Weekly cron (Monday 03:23 UTC) + manual dispatch
- Uses `git add --force` for gitignored data directory
- Bot identity for commits, no-op when data unchanged

Closes #395