### PR TITLE
refactor: use Promise.withResolvers() (Node 22+)

### DIFF
--- a/utils/background-task-queue.ts
+++ b/utils/background-task-queue.ts
@@ -209,7 +209,11 @@ export class BackgroundTaskQueue<M extends TaskModule> {
           this.worker.removeListener("message", listener);
           this.lock.release();
           cleanup();
-          reject(new Error(`Worker exited unexpectedly with code ${code}`));
+          reject(
+            new Error(
+              `Worker exited unexpectedly with code ${code} (job: ${id})`,
+            ),
+          );
         };
 
         const listener = (response: Response) => {

--- a/utils/background-task-queue.ts
+++ b/utils/background-task-queue.ts
@@ -186,28 +186,28 @@ export class BackgroundTaskQueue<M extends TaskModule> {
       this.worker.stderr.pipe(split2()).on("data", log.onstderr);
 
       try {
-        return await new Promise<RetType>((resolve, reject) => {
-          const listener = (response: Response) => {
-            if (response.id === id) {
-              this.lock.release();
-              this.worker.removeListener("message", listener);
+        const { promise, resolve, reject } = Promise.withResolvers<RetType>();
+        const listener = (response: Response) => {
+          if (response.id === id) {
+            this.lock.release();
+            this.worker.removeListener("message", listener);
 
-              const { type, result } = response;
+            const { type, result } = response;
 
-              log.setResult(type, result);
-              this.worker.stdout.off("data", log.onstdout);
-              this.worker.stderr.off("data", log.onstderr);
-              log.markTime("finish");
+            log.setResult(type, result);
+            this.worker.stdout.off("data", log.onstdout);
+            this.worker.stderr.off("data", log.onstderr);
+            log.markTime("finish");
 
-              if (type === "success") {
-                resolve(result as RetType);
-              } else {
-                reject(deserializeError(result));
-              }
+            if (type === "success") {
+              resolve(result as RetType);
+            } else {
+              reject(deserializeError(result));
             }
-          };
-          this.worker.addListener("message", listener);
-        });
+          }
+        };
+        this.worker.addListener("message", listener);
+        return await promise;
       } finally {
         await log.write();
       }
@@ -224,19 +224,19 @@ export class BackgroundTaskQueue<M extends TaskModule> {
     const msg: OperationRequest = { id, type: "init", modulePath };
     this.worker.postMessage(msg);
 
-    await new Promise<void>((resolve, reject) => {
-      this.worker.once("message", (response: Response) => {
-        if (response.id !== id) {
-          reject(new Error(`Failed to register worker module: ${modulePath}`));
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    this.worker.once("message", (response: Response) => {
+      if (response.id !== id) {
+        reject(new Error(`Failed to register worker module: ${modulePath}`));
+      } else {
+        if (response.type === "success") {
+          resolve();
         } else {
-          if (response.type === "success") {
-            resolve();
-          } else {
-            reject(deserializeError(response.result));
-          }
+          reject(deserializeError(response.result));
         }
-      });
+      }
     });
+    await promise;
   }
 
   private generateId() {

--- a/utils/background-task-queue.ts
+++ b/utils/background-task-queue.ts
@@ -182,22 +182,46 @@ export class BackgroundTaskQueue<M extends TaskModule> {
       const msg: CallRequest = { id, type: "call", input };
       this.worker.postMessage(msg);
 
-      this.worker.stdout.pipe(split2()).on("data", log.onstdout);
-      this.worker.stderr.pipe(split2()).on("data", log.onstderr);
+      const stdoutSplit = this.worker.stdout.pipe(split2());
+      const stderrSplit = this.worker.stderr.pipe(split2());
+      stdoutSplit.on("data", log.onstdout);
+      stderrSplit.on("data", log.onstderr);
+
+      const cleanup = () => {
+        stdoutSplit.off("data", log.onstdout);
+        stderrSplit.off("data", log.onstderr);
+        this.worker.stdout.unpipe(stdoutSplit);
+        this.worker.stderr.unpipe(stderrSplit);
+        log.markTime("finish");
+      };
 
       try {
         const { promise, resolve, reject } = Promise.withResolvers<RetType>();
+
+        const onWorkerError = (err: Error) => {
+          this.worker.removeListener("message", listener);
+          this.lock.release();
+          cleanup();
+          reject(err);
+        };
+
+        const onWorkerExit = (code: number | null) => {
+          this.worker.removeListener("message", listener);
+          this.lock.release();
+          cleanup();
+          reject(new Error(`Worker exited unexpectedly with code ${code}`));
+        };
+
         const listener = (response: Response) => {
           if (response.id === id) {
-            this.lock.release();
             this.worker.removeListener("message", listener);
+            this.worker.removeListener("error", onWorkerError);
+            this.worker.removeListener("exit", onWorkerExit);
+            this.lock.release();
 
             const { type, result } = response;
-
             log.setResult(type, result);
-            this.worker.stdout.off("data", log.onstdout);
-            this.worker.stderr.off("data", log.onstderr);
-            log.markTime("finish");
+            cleanup();
 
             if (type === "success") {
               resolve(result as RetType);
@@ -206,6 +230,9 @@ export class BackgroundTaskQueue<M extends TaskModule> {
             }
           }
         };
+
+        this.worker.once("error", onWorkerError);
+        this.worker.once("exit", onWorkerExit);
         this.worker.addListener("message", listener);
         return await promise;
       } finally {
@@ -225,7 +252,27 @@ export class BackgroundTaskQueue<M extends TaskModule> {
     this.worker.postMessage(msg);
 
     const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+    const onError = (err: Error) => {
+      this.worker.removeListener("exit", onExit);
+      reject(err);
+    };
+
+    const onExit = (code: number | null) => {
+      this.worker.removeListener("error", onError);
+      reject(
+        new Error(
+          `Worker exited with code ${code} during module initialization: ${modulePath}`,
+        ),
+      );
+    };
+
+    this.worker.once("error", onError);
+    this.worker.once("exit", onExit);
+
     this.worker.once("message", (response: Response) => {
+      this.worker.removeListener("error", onError);
+      this.worker.removeListener("exit", onExit);
       if (response.id !== id) {
         reject(new Error(`Failed to register worker module: ${modulePath}`));
       } else {

--- a/utils/background-task-queue.ts
+++ b/utils/background-task-queue.ts
@@ -200,6 +200,7 @@ export class BackgroundTaskQueue<M extends TaskModule> {
 
         const onWorkerError = (err: Error) => {
           this.worker.removeListener("message", listener);
+          this.worker.removeListener("exit", onWorkerExit);
           this.lock.release();
           cleanup();
           reject(err);
@@ -207,6 +208,7 @@ export class BackgroundTaskQueue<M extends TaskModule> {
 
         const onWorkerExit = (code: number | null) => {
           this.worker.removeListener("message", listener);
+          this.worker.removeListener("error", onWorkerError);
           this.lock.release();
           cleanup();
           reject(

--- a/utils/sh.ts
+++ b/utils/sh.ts
@@ -34,34 +34,41 @@ export default async function sh(
     const { promise, resolve, reject } = Promise.withResolvers<string>();
     let stdout: string[] = [];
     let stderr: string[] = [];
-    return await new Promise<string>((resolve, reject) => {
-      let stdout: string[] = [];
-      let stderr: string[] = [];
-      const child = exec(command, {
-        ...execOptions,
-        env: { ...process.env, ...execOptions.env },
-        encoding: "utf-8",
-      });
-      child.stdout!.pipe(split()).on("data", (line: string) => {
-        if (shouldStream) log.out(line);
-        stdout.push(line);
-      });
-      child.stderr!.pipe(split()).on("data", (line: string) => {
-        if (shouldStream) log.err(line);
-        stderr.push(line);
-      });
-      child.on("exit", code => {
-        if (output === "buffer") {
-          if (stdout.length) log.out(stdout.join("\n"));
-          if (stderr.length) log.err(stderr.join("\n"));
-        }
-        if (code === 0) {
-          resolve(stdout.join("\n"));
-        } else {
-          reject({ command, stdout, stderr, code });
-        }
-      });
+    const child = exec(command, {
+      ...execOptions,
+      env: { ...process.env, ...execOptions.env },
+      encoding: "utf-8",
     });
+    child.stdout!.pipe(split()).on("data", (line: string) => {
+      if (shouldStream) log.out(line);
+      stdout.push(line);
+    });
+    child.stderr!.pipe(split()).on("data", (line: string) => {
+      if (shouldStream) log.err(line);
+      stderr.push(line);
+    });
+    child.on("error", err => {
+      reject(Object.assign(err, { command, stdout, stderr, code: null }));
+    });
+    child.on("close", code => {
+      if (output === "buffer") {
+        if (stdout.length) log.out(stdout.join("\n"));
+        if (stderr.length) log.err(stderr.join("\n"));
+      }
+      if (code === 0) {
+        resolve(stdout.join("\n"));
+      } else {
+        reject(
+          Object.assign(new Error(`Command failed: ${command}`), {
+            command,
+            stdout,
+            stderr,
+            code,
+          }),
+        );
+      }
+    });
+    return await promise;
   } finally {
     if (output !== "silent") {
       console.groupEnd();

--- a/utils/sh.ts
+++ b/utils/sh.ts
@@ -34,34 +34,34 @@ export default async function sh(
     const { promise, resolve, reject } = Promise.withResolvers<string>();
     let stdout: string[] = [];
     let stderr: string[] = [];
-    const child = exec(command, {
-      ...execOptions,
-      env: { ...process.env, ...execOptions.env },
-      encoding: "utf-8",
+    return await new Promise<string>((resolve, reject) => {
+      let stdout: string[] = [];
+      let stderr: string[] = [];
+      const child = exec(command, {
+        ...execOptions,
+        env: { ...process.env, ...execOptions.env },
+        encoding: "utf-8",
+      });
+      child.stdout!.pipe(split()).on("data", (line: string) => {
+        if (shouldStream) log.out(line);
+        stdout.push(line);
+      });
+      child.stderr!.pipe(split()).on("data", (line: string) => {
+        if (shouldStream) log.err(line);
+        stderr.push(line);
+      });
+      child.on("exit", code => {
+        if (output === "buffer") {
+          if (stdout.length) log.out(stdout.join("\n"));
+          if (stderr.length) log.err(stderr.join("\n"));
+        }
+        if (code === 0) {
+          resolve(stdout.join("\n"));
+        } else {
+          reject({ command, stdout, stderr, code });
+        }
+      });
     });
-    child.stdout!.pipe(split()).on("data", (line: string) => {
-      if (shouldStream) log.out(line);
-      stdout.push(line);
-    });
-    child.stderr!.pipe(split()).on("data", (line: string) => {
-      if (shouldStream) log.err(line);
-      stderr.push(line);
-    });
-    child.on("error", err => {
-      reject({ command, stdout, stderr, code: null, error: err });
-    });
-    child.on("close", code => {
-      if (output === "buffer") {
-        if (stdout.length) log.out(stdout.join("\n"));
-        if (stderr.length) log.err(stderr.join("\n"));
-      }
-      if (code === 0) {
-        resolve(stdout.join("\n"));
-      } else {
-        reject({ command, stdout, stderr, code });
-      }
-    });
-    return await promise;
   } finally {
     if (output !== "silent") {
       console.groupEnd();

--- a/utils/sh.ts
+++ b/utils/sh.ts
@@ -31,34 +31,37 @@ export default async function sh(
   }
 
   try {
-    return await new Promise<string>((resolve, reject) => {
-      let stdout: string[] = [];
-      let stderr: string[] = [];
-      const child = exec(command, {
-        ...execOptions,
-        env: { ...process.env, ...execOptions.env },
-        encoding: "utf-8",
-      });
-      child.stdout!.pipe(split()).on("data", (line: string) => {
-        if (shouldStream) log.out(line);
-        stdout.push(line);
-      });
-      child.stderr!.pipe(split()).on("data", (line: string) => {
-        if (shouldStream) log.err(line);
-        stderr.push(line);
-      });
-      child.on("exit", code => {
-        if (output === "buffer") {
-          if (stdout.length) log.out(stdout.join("\n"));
-          if (stderr.length) log.err(stderr.join("\n"));
-        }
-        if (code === 0) {
-          resolve(stdout.join("\n"));
-        } else {
-          reject({ command, stdout, stderr, code });
-        }
-      });
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    let stdout: string[] = [];
+    let stderr: string[] = [];
+    const child = exec(command, {
+      ...execOptions,
+      env: { ...process.env, ...execOptions.env },
+      encoding: "utf-8",
     });
+    child.stdout!.pipe(split()).on("data", (line: string) => {
+      if (shouldStream) log.out(line);
+      stdout.push(line);
+    });
+    child.stderr!.pipe(split()).on("data", (line: string) => {
+      if (shouldStream) log.err(line);
+      stderr.push(line);
+    });
+    child.on("error", err => {
+      reject({ command, stdout, stderr, code: null, error: err });
+    });
+    child.on("close", code => {
+      if (output === "buffer") {
+        if (stdout.length) log.out(stdout.join("\n"));
+        if (stderr.length) log.err(stderr.join("\n"));
+      }
+      if (code === 0) {
+        resolve(stdout.join("\n"));
+      } else {
+        reject({ command, stdout, stderr, code });
+      }
+    });
+    return await promise;
   } finally {
     if (output !== "silent") {
       console.groupEnd();


### PR DESCRIPTION
## Summary
Replace `new Promise((resolve, reject) => { ... })` with `Promise.withResolvers()` in 3 call sites:
- `utils/background-task-queue.ts` — worker message listener and module registration
- `utils/sh.ts` — shell exec wrapper

Cleaner code, same behavior. Node 22+ native API.