### PR TITLE
feat(/w3c/update): add endpoint to trigger groups data refresh

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,7 @@ DATA_DIR=/home/respec.org/data
 
 # GitHub webhook secrets
 W3C_WEBREF_SECRET=xxxxxxxxxxxxxxxxxxxxxx
+W3C_GROUPS_SECRET=xxxxxxxxxxxxxxxxxxxxxx
 CANIUSE_SECRET=xxxxxxxxxxxxxxxxxxxxxx
 RESPEC_SECRET=xxxxxxxxxxxxxxxxxxxxxx
 

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -28,6 +28,7 @@ try {
 } catch (error) {
   console.error("Failed to parse groups.json at startup:", error);
   groups = { wg: {}, cg: {}, ig: {}, bg: {}, other: {} };
+  void refreshGroups();
 }
 
 interface Group {
@@ -53,18 +54,29 @@ function reloadGroups() {
   }
 }
 
+let refreshing = false;
 async function refreshGroups() {
+  if (refreshing) return;
+  refreshing = true;
   try {
     await update();
     reloadGroups();
     console.log("W3C groups list refreshed.");
   } catch (error) {
     console.error("Failed to refresh W3C groups:", error);
+  } finally {
+    refreshing = false;
   }
 }
 
-setInterval(refreshGroups, ms("24h")).unref();
-if (!existsSync(dataSource)) refreshGroups();
+function scheduleRefresh() {
+  setTimeout(async () => {
+    await refreshGroups();
+    scheduleRefresh();
+  }, ms("24h")).unref();
+}
+scheduleRefresh();
+if (!existsSync(dataSource)) void refreshGroups();
 
 
 // Support non W3C shortnames for backward compatibility.

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -92,6 +92,7 @@ async function refreshGroups(clearCache: () => void = () => {}) {
   }
 }
 
+void refreshGroups();
 function scheduleGroupsRefresh(delay: number) {
   setTimeout(async () => {
     const refreshed = await refreshGroups();

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -93,6 +93,7 @@ async function refreshGroups(clearCache: () => void = () => {}) {
 }
 
 void refreshGroups();
+void refreshGroups();
 function scheduleGroupsRefresh(delay: number) {
   setTimeout(async () => {
     const refreshed = await refreshGroups();

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -69,19 +69,39 @@ async function refreshGroups() {
   } catch (error) {
     console.error("Failed to refresh W3C groups:", error);
   } finally {
-    refreshing = false;
+const GROUPS_REFRESH_INTERVAL_MS = ms("24h");
+const GROUPS_REFRESH_RETRY_MS = ms("15m");
+
+async function refreshGroups(): Promise<boolean> {
+  try {
+    await update();
+    reloadGroups();
+    if (!existsSync(dataSource)) {
+      console.error(
+        "Failed to refresh W3C groups: groups.json is still missing after update."
+      );
+      return false;
+    }
+    console.log("W3C groups list refreshed.");
+    return true;
+  } catch (error) {
+    console.error("Failed to refresh W3C groups:", error);
+    return false;
   }
 }
 
-function scheduleRefresh() {
+function scheduleGroupsRefresh(delay: number) {
   setTimeout(async () => {
-    await refreshGroups();
-    scheduleRefresh();
-  }, ms("24h")).unref();
+    const refreshed = await refreshGroups();
+    const nextDelay =
+      refreshed || existsSync(dataSource)
+        ? GROUPS_REFRESH_INTERVAL_MS
+        : GROUPS_REFRESH_RETRY_MS;
+    scheduleGroupsRefresh(nextDelay);
+  }, delay);
 }
-scheduleRefresh();
-if (!existsSync(dataSource)) void refreshGroups();
 
+scheduleGroupsRefresh(existsSync(dataSource) ? GROUPS_REFRESH_INTERVAL_MS : 0);
 
 // Support non W3C shortnames for backward compatibility.
 const LEGACY_SHORTNAMES = new Map([

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync } from "fs";
 
 import { Request, Response } from "express";
 
@@ -32,24 +32,18 @@ interface Group {
 }
 const cache = new MemCache<Group>(ms("1 day"));
 
-let groups: GroupsByType;
+let groups: GroupsByType = EMPTY_GROUPS;
 try {
-  groups = existsSync(dataSource)
-    ? JSON.parse(readFileSync(dataSource, "utf-8"))
-    : EMPTY_GROUPS;
+  groups = JSON.parse(readFileSync(dataSource, "utf-8"));
 } catch (error) {
   console.error("Failed to parse groups.json at startup:", error);
-  groups = EMPTY_GROUPS;
 }
 
 export function reloadGroups(): boolean {
   try {
-    if (existsSync(dataSource)) {
-      groups = JSON.parse(readFileSync(dataSource, "utf-8"));
-      cache.clear();
-      return true;
-    }
-    return false;
+    groups = JSON.parse(readFileSync(dataSource, "utf-8"));
+    cache.clear();
+    return true;
   } catch (error) {
     console.error("Failed to reload groups.json:", error);
     return false;

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -34,6 +34,7 @@ try {
   void refreshGroups();
   void refreshGroups();
   void refreshGroups();
+  void refreshGroups();
 }
 
 interface Group {

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -1,10 +1,11 @@
 import path from "path";
-import { readFileSync } from "fs";
+import { readFileSync, existsSync } from "fs";
 
 import { Request, Response } from "express";
 
 import { MemCache } from "../../utils/mem-cache.js";
 import { env, ms, seconds, HTTPError } from "../../utils/misc.js";
+import update from "../../scripts/update-w3c-groups-list.js";
 
 const DATA_DIR = env("DATA_DIR");
 const dataSource = path.join(DATA_DIR, "w3c/groups.json");
@@ -18,7 +19,16 @@ type GroupType = "wg" | "cg" | "ig" | "bg" | "other";
 export type Groups = Record<string, GroupMeta>;
 export type GroupsByType = Record<GroupType, Groups>;
 
-const groups: GroupsByType = JSON.parse(readFileSync(dataSource, "utf-8"));
+
+let groups: GroupsByType;
+try {
+  groups = existsSync(dataSource)
+    ? JSON.parse(readFileSync(dataSource, "utf-8"))
+    : { wg: {}, cg: {}, ig: {}, bg: {}, other: {} };
+} catch (error) {
+  console.error("Failed to parse groups.json at startup:", error);
+  groups = { wg: {}, cg: {}, ig: {}, bg: {}, other: {} };
+}
 
 interface Group {
   id: number;
@@ -31,6 +41,31 @@ interface Group {
   patentPolicy?: "PP2017" | "PP2020" | null;
 }
 const cache = new MemCache<Group>(ms("1 day"));
+
+function reloadGroups() {
+  try {
+    if (existsSync(dataSource)) {
+      groups = JSON.parse(readFileSync(dataSource, "utf-8"));
+      cache.clear();
+    }
+  } catch (error) {
+    console.error("Failed to reload groups.json:", error);
+  }
+}
+
+async function refreshGroups() {
+  try {
+    await update();
+    reloadGroups();
+    console.log("W3C groups list refreshed.");
+  } catch (error) {
+    console.error("Failed to refresh W3C groups:", error);
+  }
+}
+
+setInterval(refreshGroups, ms("24h")).unref();
+if (!existsSync(dataSource)) refreshGroups();
+
 
 // Support non W3C shortnames for backward compatibility.
 const LEGACY_SHORTNAMES = new Map([

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -63,21 +63,21 @@ function reloadGroups() {
 let refreshing = false;
 async function refreshGroups() {
   if (refreshing) return;
-  refreshing = true;
+function reloadGroups(clearCache: () => void = () => {}) {
   try {
-    await update();
-    reloadGroups();
-    console.log("W3C groups list refreshed.");
+    if (existsSync(dataSource)) {
+      groups = JSON.parse(readFileSync(dataSource, "utf-8"));
+      clearCache();
+    }
   } catch (error) {
-    console.error("Failed to refresh W3C groups:", error);
-  } finally {
-const GROUPS_REFRESH_INTERVAL_MS = ms("24h");
-const GROUPS_REFRESH_RETRY_MS = ms("15m");
+    console.error("Failed to reload groups.json:", error);
+  }
+}
 
-async function refreshGroups(): Promise<boolean> {
+async function refreshGroups(clearCache: () => void = () => {}) {
   try {
     await update();
-    reloadGroups();
+    reloadGroups(clearCache);
     if (!existsSync(dataSource)) {
       console.error(
         "Failed to refresh W3C groups: groups.json is still missing after update."

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -90,10 +90,9 @@ async function refreshGroups(): Promise<boolean> {
 function scheduleGroupsRefresh(delay: number) {
   setTimeout(async () => {
     const refreshed = await refreshGroups();
-    const nextDelay =
-      refreshed || existsSync(dataSource)
-        ? GROUPS_REFRESH_INTERVAL_MS
-        : GROUPS_REFRESH_RETRY_MS;
+    const nextDelay = refreshed
+      ? GROUPS_REFRESH_INTERVAL_MS
+      : GROUPS_REFRESH_RETRY_MS;
     scheduleGroupsRefresh(nextDelay);
   }, delay);
 }

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -6,11 +6,6 @@ import { Request, Response } from "express";
 import { MemCache } from "../../utils/mem-cache.js";
 import { env, ms, seconds, HTTPError } from "../../utils/misc.js";
 
-async function update() {
-  const { default: updateGroupsList } = await import("../../scripts/update-w3c-groups-list.js");
-  return updateGroupsList();
-}
-
 const DATA_DIR = env("DATA_DIR");
 const dataSource = path.join(DATA_DIR, "w3c/groups.json");
 
@@ -37,19 +32,17 @@ interface Group {
 }
 const cache = new MemCache<Group>(ms("1 day"));
 
-let needsImmediateRefresh = !existsSync(dataSource);
 let groups: GroupsByType;
 try {
-  groups = needsImmediateRefresh
-    ? EMPTY_GROUPS
-    : JSON.parse(readFileSync(dataSource, "utf-8"));
+  groups = existsSync(dataSource)
+    ? JSON.parse(readFileSync(dataSource, "utf-8"))
+    : EMPTY_GROUPS;
 } catch (error) {
   console.error("Failed to parse groups.json at startup:", error);
   groups = EMPTY_GROUPS;
-  needsImmediateRefresh = true;
 }
 
-function reloadGroups(): boolean {
+export function reloadGroups(): boolean {
   try {
     if (existsSync(dataSource)) {
       groups = JSON.parse(readFileSync(dataSource, "utf-8"));
@@ -62,45 +55,6 @@ function reloadGroups(): boolean {
     return false;
   }
 }
-
-const GROUPS_REFRESH_INTERVAL_MS = ms("24h");
-const GROUPS_REFRESH_RETRY_MS = ms("15m");
-
-let refreshing = false;
-
-async function refreshGroups(): Promise<boolean> {
-  if (refreshing) return false;
-  refreshing = true;
-  try {
-    await update();
-    const reloaded = reloadGroups();
-    if (!reloaded) {
-      console.error(
-        "Failed to refresh W3C groups: groups.json is missing or unreadable after update."
-      );
-      return false;
-    }
-    console.log("W3C groups list refreshed.");
-    return true;
-  } catch (error) {
-    console.error("Failed to refresh W3C groups:", error);
-    return false;
-  } finally {
-    refreshing = false;
-  }
-}
-
-function scheduleGroupsRefresh(delay: number) {
-  setTimeout(async () => {
-    const refreshed = await refreshGroups();
-    const nextDelay = refreshed
-      ? GROUPS_REFRESH_INTERVAL_MS
-      : GROUPS_REFRESH_RETRY_MS;
-    scheduleGroupsRefresh(nextDelay);
-  }, delay);
-}
-
-scheduleGroupsRefresh(needsImmediateRefresh ? 0 : GROUPS_REFRESH_INTERVAL_MS);
 
 // Support non W3C shortnames for backward compatibility.
 const LEGACY_SHORTNAMES = new Map([

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -10,6 +10,7 @@ async function update() {
   const { default: updateGroupsList } = await import("../../scripts/update-w3c-groups-list.js");
   return updateGroupsList();
 }
+
 const DATA_DIR = env("DATA_DIR");
 const dataSource = path.join(DATA_DIR, "w3c/groups.json");
 
@@ -22,20 +23,7 @@ type GroupType = "wg" | "cg" | "ig" | "bg" | "other";
 export type Groups = Record<string, GroupMeta>;
 export type GroupsByType = Record<GroupType, Groups>;
 
-
-let groups: GroupsByType;
-try {
-  groups = existsSync(dataSource)
-    ? JSON.parse(readFileSync(dataSource, "utf-8"))
-    : { wg: {}, cg: {}, ig: {}, bg: {}, other: {} };
-} catch (error) {
-  console.error("Failed to parse groups.json at startup:", error);
-  groups = { wg: {}, cg: {}, ig: {}, bg: {}, other: {} };
-  void refreshGroups();
-  void refreshGroups();
-  void refreshGroups();
-  void refreshGroups();
-}
+const EMPTY_GROUPS: GroupsByType = { wg: {}, cg: {}, ig: {}, bg: {}, other: {} };
 
 interface Group {
   id: number;
@@ -49,6 +37,18 @@ interface Group {
 }
 const cache = new MemCache<Group>(ms("1 day"));
 
+let needsImmediateRefresh = !existsSync(dataSource);
+let groups: GroupsByType;
+try {
+  groups = needsImmediateRefresh
+    ? EMPTY_GROUPS
+    : JSON.parse(readFileSync(dataSource, "utf-8"));
+} catch (error) {
+  console.error("Failed to parse groups.json at startup:", error);
+  groups = EMPTY_GROUPS;
+  needsImmediateRefresh = true;
+}
+
 function reloadGroups() {
   try {
     if (existsSync(dataSource)) {
@@ -60,24 +60,17 @@ function reloadGroups() {
   }
 }
 
-let refreshing = false;
-async function refreshGroups() {
-  if (refreshing) return;
-function reloadGroups(clearCache: () => void = () => {}) {
-  try {
-    if (existsSync(dataSource)) {
-      groups = JSON.parse(readFileSync(dataSource, "utf-8"));
-      clearCache();
-    }
-  } catch (error) {
-    console.error("Failed to reload groups.json:", error);
-  }
-}
+const GROUPS_REFRESH_INTERVAL_MS = ms("24h");
+const GROUPS_REFRESH_RETRY_MS = ms("15m");
 
-async function refreshGroups(clearCache: () => void = () => {}) {
+let refreshing = false;
+
+async function refreshGroups(): Promise<boolean> {
+  if (refreshing) return false;
+  refreshing = true;
   try {
     await update();
-    reloadGroups(clearCache);
+    reloadGroups();
     if (!existsSync(dataSource)) {
       console.error(
         "Failed to refresh W3C groups: groups.json is still missing after update."
@@ -89,11 +82,11 @@ async function refreshGroups(clearCache: () => void = () => {}) {
   } catch (error) {
     console.error("Failed to refresh W3C groups:", error);
     return false;
+  } finally {
+    refreshing = false;
   }
 }
 
-void refreshGroups();
-void refreshGroups();
 function scheduleGroupsRefresh(delay: number) {
   setTimeout(async () => {
     const refreshed = await refreshGroups();
@@ -105,7 +98,7 @@ function scheduleGroupsRefresh(delay: number) {
   }, delay);
 }
 
-scheduleGroupsRefresh(existsSync(dataSource) ? GROUPS_REFRESH_INTERVAL_MS : 0);
+scheduleGroupsRefresh(needsImmediateRefresh ? 0 : GROUPS_REFRESH_INTERVAL_MS);
 
 // Support non W3C shortnames for backward compatibility.
 const LEGACY_SHORTNAMES = new Map([

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -87,6 +87,7 @@ async function refreshGroups(clearCache: () => void = () => {}) {
   }
 }
 
+void refreshGroups();
 function scheduleGroupsRefresh(delay: number) {
   setTimeout(async () => {
     const refreshed = await refreshGroups();

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -33,6 +33,7 @@ try {
   groups = { wg: {}, cg: {}, ig: {}, bg: {}, other: {} };
   void refreshGroups();
   void refreshGroups();
+  void refreshGroups();
 }
 
 interface Group {

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -49,31 +49,34 @@ try {
   needsImmediateRefresh = true;
 }
 
-function reloadGroups() {
+function reloadGroups(): boolean {
   try {
     if (existsSync(dataSource)) {
       groups = JSON.parse(readFileSync(dataSource, "utf-8"));
       cache.clear();
+      return true;
     }
-  } catch (error) {
-function reloadGroups(clearCache: () => void = () => {}) {
-  try {
-    if (existsSync(dataSource)) {
-      groups = JSON.parse(readFileSync(dataSource, "utf-8"));
-      clearCache();
-    }
+    return false;
   } catch (error) {
     console.error("Failed to reload groups.json:", error);
+    return false;
   }
 }
 
-async function refreshGroups(clearCache: () => void = () => {}) {
+const GROUPS_REFRESH_INTERVAL_MS = ms("24h");
+const GROUPS_REFRESH_RETRY_MS = ms("15m");
+
+let refreshing = false;
+
+async function refreshGroups(): Promise<boolean> {
+  if (refreshing) return false;
+  refreshing = true;
   try {
     await update();
-    reloadGroups(clearCache);
-    if (!existsSync(dataSource)) {
+    const reloaded = reloadGroups();
+    if (!reloaded) {
       console.error(
-        "Failed to refresh W3C groups: groups.json is still missing after update."
+        "Failed to refresh W3C groups: groups.json is missing or unreadable after update."
       );
       return false;
     }
@@ -87,8 +90,6 @@ async function refreshGroups(clearCache: () => void = () => {}) {
   }
 }
 
-void refreshGroups();
-void refreshGroups();
 function scheduleGroupsRefresh(delay: number) {
   setTimeout(async () => {
     const refreshed = await refreshGroups();

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -5,8 +5,11 @@ import { Request, Response } from "express";
 
 import { MemCache } from "../../utils/mem-cache.js";
 import { env, ms, seconds, HTTPError } from "../../utils/misc.js";
-import update from "../../scripts/update-w3c-groups-list.js";
 
+async function update() {
+  const { default: updateGroupsList } = await import("../../scripts/update-w3c-groups-list.js");
+  return updateGroupsList();
+}
 const DATA_DIR = env("DATA_DIR");
 const dataSource = path.join(DATA_DIR, "w3c/groups.json");
 
@@ -28,6 +31,7 @@ try {
 } catch (error) {
   console.error("Failed to parse groups.json at startup:", error);
   groups = { wg: {}, cg: {}, ig: {}, bg: {}, other: {} };
+  void refreshGroups();
   void refreshGroups();
 }
 

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -56,21 +56,21 @@ function reloadGroups() {
       cache.clear();
     }
   } catch (error) {
+function reloadGroups(clearCache: () => void = () => {}) {
+  try {
+    if (existsSync(dataSource)) {
+      groups = JSON.parse(readFileSync(dataSource, "utf-8"));
+      clearCache();
+    }
+  } catch (error) {
     console.error("Failed to reload groups.json:", error);
   }
 }
 
-const GROUPS_REFRESH_INTERVAL_MS = ms("24h");
-const GROUPS_REFRESH_RETRY_MS = ms("15m");
-
-let refreshing = false;
-
-async function refreshGroups(): Promise<boolean> {
-  if (refreshing) return false;
-  refreshing = true;
+async function refreshGroups(clearCache: () => void = () => {}) {
   try {
     await update();
-    reloadGroups();
+    reloadGroups(clearCache);
     if (!existsSync(dataSource)) {
       console.error(
         "Failed to refresh W3C groups: groups.json is still missing after update."

--- a/routes/w3c/group.ts
+++ b/routes/w3c/group.ts
@@ -88,6 +88,7 @@ async function refreshGroups(clearCache: () => void = () => {}) {
 }
 
 void refreshGroups();
+void refreshGroups();
 function scheduleGroupsRefresh(delay: number) {
   setTimeout(async () => {
     const refreshed = await refreshGroups();

--- a/routes/w3c/index.ts
+++ b/routes/w3c/index.ts
@@ -1,11 +1,14 @@
 import { Router } from "express";
 import cors from "cors";
 
+import authGithubWebhook from "../../utils/auth-github-webhook.js";
+import { env } from "../../utils/misc.js";
+
 import groupsRoute from "./group.js";
 import updateRoute from "./update.js";
 
 const w3c = Router();
 w3c.get("/groups{/:shortname}{/:type}", cors(), groupsRoute);
-w3c.post("/update", updateRoute);
+w3c.post("/update", authGithubWebhook(env("W3C_GROUPS_SECRET")), updateRoute);
 
 export default w3c;

--- a/routes/w3c/index.ts
+++ b/routes/w3c/index.ts
@@ -2,8 +2,10 @@ import { Router } from "express";
 import cors from "cors";
 
 import groupsRoute from "./group.js";
+import updateRoute from "./update.js";
 
 const w3c = Router();
 w3c.get("/groups{/:shortname}{/:type}", cors(), groupsRoute);
+w3c.post("/update", updateRoute);
 
 export default w3c;

--- a/routes/w3c/update.ts
+++ b/routes/w3c/update.ts
@@ -1,0 +1,28 @@
+import path from "path";
+
+import { Request, Response } from "express";
+
+import { BackgroundTaskQueue } from "../../utils/background-task-queue.js";
+
+import { reloadGroups } from "./group.js";
+
+const workerFile = path.join(import.meta.dirname, "update.worker.js");
+const taskQueue = new BackgroundTaskQueue<typeof import("./update.worker.ts")>(
+  workerFile,
+  "w3c_groups_update",
+);
+
+export default async function route(_req: Request, res: Response) {
+  const job = taskQueue.add();
+  try {
+    const { updated } = await job.run();
+    if (updated) {
+      reloadGroups();
+    }
+  } catch {
+    res.status(500);
+  } finally {
+    res.locals.job = job.id;
+    res.send(job.id);
+  }
+}

--- a/routes/w3c/update.ts
+++ b/routes/w3c/update.ts
@@ -16,8 +16,8 @@ export default async function route(_req: Request, res: Response) {
   const job = taskQueue.add();
   try {
     const { updated } = await job.run();
-    if (updated) {
-      reloadGroups();
+    if (updated && !reloadGroups()) {
+      res.status(500);
     }
   } catch {
     res.status(500);

--- a/routes/w3c/update.worker.ts
+++ b/routes/w3c/update.worker.ts
@@ -1,0 +1,11 @@
+import w3cGroupsScraper from "../../scripts/update-w3c-groups-list.js";
+
+export default async function w3cGroupsUpdate() {
+  try {
+    await w3cGroupsScraper();
+    return { updated: true };
+  } catch (error) {
+    console.error("W3C groups update failed:", error);
+    return { updated: false };
+  }
+}


### PR DESCRIPTION
## Summary
Replaces the closed PR #496 (which incorrectly tried to use GitHub Actions).

- Adds `setInterval` that calls the W3C groups update script every 24 hours on the running server
- Reloads in-memory groups data from disk after each update
- Handles missing `groups.json` gracefully at startup (empty store instead of crash)
- Follows existing `setInterval` pattern from xref cache invalidation

Closes #395