### PR TITLE
fix: address trust proxy bypass and noisy 404s

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -21,7 +21,7 @@ const app = express();
 app.use(compression());
 
 // logging
-app.enable("trust proxy"); // for :remote-addr
+app.set("trust proxy", 2); // Cloudflare → nginx → Express
 app.use(logging.stdout());
 app.use(logging.stderr());
 


### PR DESCRIPTION
## Summary

- **Trust proxy**: `express-rate-limit` v8.4+ throws `ERR_ERL_PERMISSIVE_TRUST_PROXY` because `app.enable("trust proxy")` sets it to `true`, allowing anyone to spoof `X-Forwarded-For` and bypass rate limiting. The production proxy chain is **Client → Cloudflare → nginx → Express (PM2)** (2 hops), so this changes `trust proxy` from `true` to `2`.
- **Static files**: Adds `robots.txt` and `favicon.ico` to `static/`. These two paths account for ~100 of the last 1000 error log entries from legitimate crawlers and browsers. The favicon is generated from the existing `respec-logo-square.png` at 32x32.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 40 specs, 0 failures
- [ ] Deploy and verify the `ValidationError` no longer appears in server logs
- [ ] Verify `req.ip` / `:remote-addr` still logs real client IPs (not proxy IPs)
- [ ] Verify `/robots.txt` and `/favicon.ico` return 200