### PR TITLE
docs: add implementationStatus to docs page

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -239,6 +239,7 @@
       <section data-include="formerEditors"></section>
       <section data-include="github"></section>
       <section data-include="highlightVars"></section>
+      <section data-include="implementationStatus"></section>
       <section data-include="isPreview"></section>
       <section data-include="license"></section>
       <section data-include-name="lint" data-max-toc="2">


### PR DESCRIPTION
Includes the new `implementationStatus` config option (added in respec v37.0.0) in the generated docs at respec.org/docs.

The wiki page was added in speced/respec.wiki@5bd2fac.