### PR TITLE
feat(monitor): add /monitor/usage health check endpoint

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -16,6 +16,7 @@ import respecRouter from "./routes/respec/index.js";
 import w3cRouter from "./routes/w3c/index.js";
 import baselineRouter from "./routes/api/baseline/index.js";
 import wellKnownRouter from "./routes/well-known/index.js";
+import monitorRouter from "./routes/monitor/index.js";
 import docsRouter from "./routes/docs/index.js";
 
 const app = express();
@@ -52,6 +53,7 @@ app.use("/github/:org/:repo", githubRouter);
 app.use("/respec", respecRouter);
 app.use("/w3c", w3cRouter);
 app.use("/.well-known", wellKnownRouter);
+app.use("/monitor", monitorRouter);
 app.use("/docs", docsRouter);
 app.get("/", (_req, res) => res.redirect("/docs/"));
 

--- a/routes/api/baseline/update.ts
+++ b/routes/api/baseline/update.ts
@@ -6,7 +6,7 @@ import { BackgroundTaskQueue } from "../../../utils/background-task-queue.js";
 import { store } from "./lib/store-init.js";
 
 const workerFile = path.join(import.meta.dirname, "update.worker.js");
-const taskQueue = new BackgroundTaskQueue<typeof import("./update.worker")>(
+const taskQueue = new BackgroundTaskQueue<typeof import("./update.worker.ts")>(
   workerFile,
   "baseline_update",
 );

--- a/routes/monitor/index.ts
+++ b/routes/monitor/index.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+
+import usageRoute from "./usage.js";
+
+const monitor = Router();
+monitor.get("/usage", usageRoute);
+
+export default monitor;

--- a/routes/monitor/usage.ts
+++ b/routes/monitor/usage.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from "express";
+import { readFileSync } from "fs";
+import path from "path";
+
+import { PROJECT_ROOT } from "../../utils/constants.js";
+
+const { version } = JSON.parse(
+  readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf-8"),
+);
+
+export default function route(_req: Request, res: Response) {
+  const { heapUsed, heapTotal } = process.memoryUsage();
+  res.json({
+    name: "respec.org",
+    version,
+    uptime: process.uptime(),
+    heapUsed,
+    heapTotal,
+  });
+}

--- a/routes/monitor/usage.ts
+++ b/routes/monitor/usage.ts
@@ -4,9 +4,12 @@ import path from "path";
 
 import { PROJECT_ROOT } from "../../utils/constants.js";
 
-const { version } = JSON.parse(
-  readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf-8"),
-);
+let version = "unknown";
+try {
+  ({ version } = JSON.parse(
+    readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf-8"),
+  ));
+} catch {}
 
 export default function route(_req: Request, res: Response) {
   const { heapUsed, heapTotal } = process.memoryUsage();

--- a/routes/monitor/usage.ts
+++ b/routes/monitor/usage.ts
@@ -6,13 +6,19 @@ import { PROJECT_ROOT } from "../../utils/constants.js";
 
 let version = "unknown";
 try {
-  ({ version } = JSON.parse(
+  const pkg = JSON.parse(
     readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf-8"),
-  ));
-} catch {}
+  );
+  if (typeof pkg.version === "string" && pkg.version) {
+    version = pkg.version;
+  }
+} catch (error) {
+  console.error("Failed to read version from package.json:", error);
+}
 
 export default function route(_req: Request, res: Response) {
   const { heapUsed, heapTotal } = process.memoryUsage();
+  res.set("Cache-Control", "no-store");
   res.json({
     name: "respec.org",
     version,

--- a/tests/routes/monitor/usage.test.js
+++ b/tests/routes/monitor/usage.test.js
@@ -1,0 +1,54 @@
+const { default: route } = await import(
+  "../../../build/routes/monitor/usage.js"
+);
+
+function mockRes() {
+  const res = {
+    _status: 200,
+    _body: undefined,
+    _headers: {},
+    status(code) { res._status = code; return res; },
+    json(body) { res._body = body; return res; },
+    set(header, value) { res._headers[header] = value; return res; },
+  };
+  return res;
+}
+
+describe("monitor/usage", () => {
+  it("returns all required fields with correct types", () => {
+    const res = mockRes();
+    route({}, res);
+    expect(res._body).toBeDefined();
+    expect(typeof res._body.name).toBe("string");
+    expect(typeof res._body.version).toBe("string");
+    expect(typeof res._body.uptime).toBe("number");
+    expect(typeof res._body.heapUsed).toBe("number");
+    expect(typeof res._body.heapTotal).toBe("number");
+  });
+
+  it("returns respec.org as the service name", () => {
+    const res = mockRes();
+    route({}, res);
+    expect(res._body.name).toBe("respec.org");
+  });
+
+  it("sets Cache-Control to no-store", () => {
+    const res = mockRes();
+    route({}, res);
+    expect(res._headers["Cache-Control"]).toBe("no-store");
+  });
+
+  it("returns positive uptime", () => {
+    const res = mockRes();
+    route({}, res);
+    expect(res._body.uptime).toBeGreaterThan(0);
+  });
+
+  it("returns positive heap values", () => {
+    const res = mockRes();
+    route({}, res);
+    expect(res._body.heapUsed).toBeGreaterThan(0);
+    expect(res._body.heapTotal).toBeGreaterThan(0);
+    expect(res._body.heapTotal).toBeGreaterThanOrEqual(res._body.heapUsed);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `GET /monitor/usage` endpoint returning `{ name, version, uptime, heapUsed, heapTotal }`
- Compatible with the [W3C monitoring dashboard](https://www.w3.org/2020/12/express-monitor/monitor.html)
- Also fixes a missing `.ts` extension on the baseline update worker import (build was broken on main)

Closes #190

## Test plan

- [ ] `pnpm run build` passes
- [ ] `pnpm test` passes
- [ ] `curl localhost:8000/monitor/usage` returns valid JSON with expected fields
- [ ] Register `https://respec.org/monitor` on the W3C monitoring dashboard after deploy