### PR TITLE
fix(api/baseline): add .ts extension to worker type import

### DIFF
--- a/routes/api/baseline/update.ts
+++ b/routes/api/baseline/update.ts
@@ -6,7 +6,7 @@ import { BackgroundTaskQueue } from "../../../utils/background-task-queue.js";
 import { store } from "./lib/store-init.js";
 
 const workerFile = path.join(import.meta.dirname, "update.worker.js");
-const taskQueue = new BackgroundTaskQueue<typeof import("./update.worker")>(
+const taskQueue = new BackgroundTaskQueue<typeof import("./update.worker.ts")>(
   workerFile,
   "baseline_update",
 );


### PR DESCRIPTION
## Summary
- The baseline worker type import was missing the `.ts` extension, causing a build failure with TypeScript 6 + `nodenext` module resolution.
- The other workers (`xref`, `caniuse`) already use the `.ts` extension — this aligns the baseline worker with them.

## Test plan
- [x] `pnpm run build` passes (was failing with `TS2307: Cannot find module './update.worker'`)