### PR TITLE
fix(pm2): define `max_memory_restart` for production

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -9,6 +9,7 @@ const app = {
   env_production: {
     NODE_ENV: "production",
   },
+  max_memory_restart: "700M",
 };
 
 module.exports = { apps: [app] };


### PR DESCRIPTION
Goodie from pm2 v7. 

Closes #514 